### PR TITLE
docs(README): rename to Catalyst Design System and add production warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 This is a single project with a package of React UI components for Reaction's Catalyst UI, the operator tool of Reaction:
 
 - [`@reactioncommerce/catalyst`](https://www.npmjs.com/package/@reactioncommerce/catalyst): See the [package.json](https://github.com/reactioncommerce/catalyst/blob/master/package/package.json) in [`/package`](https://github.com/reactioncommerce/catalyst/tree/master/package) folder.
-- [Reaction Design System](https://designsystem.reactioncommerce.com/): See the root [package.json](https://github.com/reactioncommerce/catalyst/blob/master/package.json).
+- [Reaction Design System](https://catalyst.reactioncommerce.com/): See the root [package.json](https://github.com/reactioncommerce/catalyst/blob/master/package.json).
 
 We use the [React Styleguidist](https://react-styleguidist.js.org/) package to run and build the Reaction Design System website, and running the style guide locally doubles as an interactive playground for developing and testing the components.
 
 ## Use the React components in your project
 
-Refer to the [Reaction Design System docs](https://designsystem.reactioncommerce.com/#!/Using%20Components)
+Refer to the [Reaction Design System docs](https://catalyst.reactioncommerce.com/#!/Using%20Components)
 
 ## Contribute to this project
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Reaction Component Library & Design System
+# Catalyst Design System
 
 [![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/components.svg)](https://www.npmjs.com/package/@reactioncommerce/catalyst)
  [![CircleCI](https://circleci.com/gh/reactioncommerce/catalyst.svg?style=svg)](https://circleci.com/gh/reactioncommerce/catalyst)
 
-![Reaction Design System](https://blog.reactioncommerce.com/content/images/2018/09/style-guide-artwork.jpg)
+> ⚠️ This project is a work-in-progress and not ready for usage.
 
-This is a single project with a package of commerce-focused React UI components and the code for the Reaction Design System website:
+This is a single project with a package of React UI components for Reaction's Catalyst UI, the operator tool of Reaction:
 
 - [`@reactioncommerce/catalyst`](https://www.npmjs.com/package/@reactioncommerce/catalyst): See the [package.json](https://github.com/reactioncommerce/catalyst/blob/master/package/package.json) in [`/package`](https://github.com/reactioncommerce/catalyst/tree/master/package) folder.
 - [Reaction Design System](https://designsystem.reactioncommerce.com/): See the root [package.json](https://github.com/reactioncommerce/catalyst/blob/master/package.json).
@@ -22,7 +22,7 @@ Refer to the [contributor docs](./docs)
 
 ## License
 
-Copyright 2018 Reaction Commerce
+Copyright 2019 Reaction Commerce
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Reaction Design System and Component Library - Contributor Docs
+# Catalyst Design System and Component Library - Contributor Docs
 
 ## Getting Started
 


### PR DESCRIPTION
Resolves #11
Impact: **minor**  
Type: **docs**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component
none

## Screenshots
none

## Breaking changes
none

## Documentation changes
- Changed all links from https://designsystem.reactioncommerce.com/ to https://catalyst.reactioncommerce.com/
- Changed all names from `Reaction Design System` to `Catalyst Design System`
- Changed "ecommerce components" to "operator components"

## Testing
1. Read the README
1. Read the docs/README