### PR TITLE
fix(button): add muitheme to button; add Error button; add reactestlib; fix all tests

### DIFF
--- a/.reaction/scripts/templates/Component.js.template
+++ b/.reaction/scripts/templates/Component.js.template
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import withStyles from "@material-ui/core/styles";
+import { withStyles, createMuiTheme } from '@material-ui/core/styles';
 
 const styles = (theme) => {
   root: {

--- a/.reaction/scripts/templates/Component.test.js.template
+++ b/.reaction/scripts/templates/Component.test.js.template
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "../../tests/index.js";
+import { render } from "../../tests/index.js";
 import COMPONENT from "./COMPONENT";
-
-afterEach(cleanup);
 
 test("basic snapshot - only default props", () => {
   const { asFragment } = render(<COMPONENT></COMPONENT>);

--- a/.reaction/scripts/templates/Component.test.js.template
+++ b/.reaction/scripts/templates/Component.test.js.template
@@ -1,11 +1,10 @@
 import React from "react";
-import renderer from "react-test-renderer";
-import { shallow } from "enzyme";
+import { cleanup, render } from "../../tests/index.js";
 import COMPONENT from "./COMPONENT";
 
-test("basic snapshot", () => {
-  const component = renderer.create(<COMPONENT />);
+afterEach(cleanup);
 
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+test("basic snapshot - only default props", () => {
+  const { asFragment } = render(<COMPONENT></COMPONENT>);
+  expect(asFragment()).toMatchSnapshot();
 });

--- a/babel.config.js
+++ b/babel.config.js
@@ -76,7 +76,6 @@ module.exports = function (api) {
     ignore = [
       "**/*.test.js",
       "__snapshots__",
-      "**/setupTests.js",
       "**/tests",
       "**/scripts"
     ];

--- a/babel.config.js
+++ b/babel.config.js
@@ -76,6 +76,7 @@ module.exports = function (api) {
     ignore = [
       "**/*.test.js",
       "__snapshots__",
+      "**/setupTests.js",
       "**/tests",
       "**/scripts"
     ];

--- a/config/paths.js
+++ b/config/paths.js
@@ -48,7 +48,6 @@ module.exports = {
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
   yarnLockFile: resolveApp('yarn.lock'),
-  testsSetup: resolveApp('src/setupTests.js'),
   appNodeModules: resolveApp('node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),

--- a/config/paths.js
+++ b/config/paths.js
@@ -47,6 +47,7 @@ module.exports = {
   appIndexJs: resolveApp('src/index.js'),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
+  tests: resolveApp('src/tests/index.js'),
   yarnLockFile: resolveApp('yarn.lock'),
   appNodeModules: resolveApp('node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),

--- a/config/paths.js
+++ b/config/paths.js
@@ -49,6 +49,7 @@ module.exports = {
   appSrc: resolveApp('src'),
   tests: resolveApp('src/tests/index.js'),
   yarnLockFile: resolveApp('yarn.lock'),
+  testsSetup: resolveApp('src/setupTests.js'),
   appNodeModules: resolveApp('node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),

--- a/package.json
+++ b/package.json
@@ -38,7 +38,12 @@
     "rules": {
       "node/no-unsupported-features/es-syntax": "off",
       "node/no-unpublished-require": "off",
-      "prefer-arrow-callback": [ "error", { "allowNamedFunctions": true } ]
+      "prefer-arrow-callback": [
+        "error",
+        {
+          "allowNamedFunctions": true
+        }
+      ]
     }
   },
   "eslintIgnore": [
@@ -59,6 +64,10 @@
       "!**/vendor/**"
     ],
     "coverageDirectory": "reports/coverage",
+    "moduleDirectories": [
+      "<rootDir>/package/src/",
+      "<rootDir>/package/src/tests"
+    ],
     "moduleFileExtensions": [
       "web.js",
       "mjs",
@@ -76,7 +85,7 @@
       "<rootDir>/config/polyfills.js"
     ],
     "setupFilesAfterEnv": [
-      "<rootDir>/package/src/setupTests.js"
+      "@testing-library/react/cleanup-after-each"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/config/",
@@ -121,6 +130,7 @@
     "@commitlint/cli": "~7.0.0",
     "@commitlint/config-conventional": "~7.0.1",
     "@reactioncommerce/eslint-config": "~2.0.0",
+    "@testing-library/react": "^8.0.6",
     "adr": "~1.1.1",
     "autoprefixer": "~7.1.6",
     "babel-core": "~7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -64,10 +64,6 @@
       "!**/vendor/**"
     ],
     "coverageDirectory": "reports/coverage",
-    "moduleDirectories": [
-      "<rootDir>/package/src/",
-      "<rootDir>/package/src/tests"
-    ],
     "moduleFileExtensions": [
       "web.js",
       "mjs",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,10 @@
     "setupFiles": [
       "<rootDir>/config/polyfills.js"
     ],
+    "setupFilesAfterEnv": [
+      "react-testing-library/cleanup-after-each",
+      "jest-dom/extend-expect"
+    ],
     "testPathIgnorePatterns": [
       "<rootDir>/config/",
       "<rootDir>/node_modules/",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,6 @@
     "raf": "~3.4.1",
     "react-dev-utils": "~7.0.1",
     "react-styleguidist": "^9.1.11",
-    "react-test-renderer": "~16.8.6",
     "replace-in-files": "~1.1.4",
     "rimraf": "~2.6.3",
     "semantic-release": "~15.13.3",

--- a/package.json
+++ b/package.json
@@ -81,8 +81,7 @@
       "<rootDir>/config/polyfills.js"
     ],
     "setupFilesAfterEnv": [
-      "react-testing-library/cleanup-after-each",
-      "jest-dom/extend-expect"
+      "<rootDir>/package/src/setupTests.js"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/config/",

--- a/package.json
+++ b/package.json
@@ -80,9 +80,6 @@
     "setupFiles": [
       "<rootDir>/config/polyfills.js"
     ],
-    "setupFilesAfterEnv": [
-      "@testing-library/react/cleanup-after-each"
-    ],
     "testPathIgnorePatterns": [
       "<rootDir>/config/",
       "<rootDir>/node_modules/",

--- a/package.json
+++ b/package.json
@@ -136,8 +136,6 @@
     "css-loader": "~0.28.11",
     "dotenv": "~4.0.0",
     "dotenv-expand": "~4.0.1",
-    "enzyme": "~3.8.0",
-    "enzyme-adapter-react-16": "~1.8.0",
     "eslint": "~5.12.1",
     "eslint-loader": "~1.9.0",
     "eslint-plugin-babel": "~5.3.0",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@commitlint/cli": "~7.0.0",
     "@commitlint/config-conventional": "~7.0.1",
     "@reactioncommerce/eslint-config": "~2.0.0",
+    "@testing-library/jest-dom": "^4.0.0",
     "@testing-library/react": "^8.0.6",
     "adr": "~1.1.1",
     "autoprefixer": "~7.1.6",

--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -32,6 +32,7 @@ const useStyles = makeStyles((theme) => ({
     }
   }
 }));
+
 /**
  * @name Button
  * @param {Object} props Component props
@@ -79,11 +80,11 @@ function Button(props) {
 
 Button.propTypes = {
   /**
-   * What goes here?
+   * The content of the Button
    */
   children: PropTypes.node,
   /**
-   * CSS Classes
+   * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
   /**

--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -1,11 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
-// import withStyles from "@material-ui/core/styles/withStyles";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import MuiButton from "@material-ui/core/Button";
+import makeStyles from "@material-ui/core/styles/makeStyles";
 
-/*
-const styles = (theme) => ({
+const useStyles = makeStyles((theme) => ({
   buttonProgress: {
     marginLeft: theme.spacing.unit
   },
@@ -32,9 +31,7 @@ const styles = (theme) => ({
       }
     }
   }
-});
-*/
-
+}));
 /**
  * @name Button
  * @param {Object} props Component props
@@ -43,12 +40,13 @@ const styles = (theme) => ({
 function Button(props) {
   const {
     children,
-    classes,
     color,
     disabled,
     isWaiting,
     ...otherProps
   } = props;
+
+  const classes = useStyles();
 
   if (color === "danger") {
     return (
@@ -79,6 +77,33 @@ function Button(props) {
   );
 }
 
+Button.propTypes = {
+  /**
+   * What goes here?
+   */
+  children: PropTypes.node,
+  /**
+   * Classes
+   */
+  classes: PropTypes.object,
+  /**
+   * Color: "danger", "primary", "secondary"
+   */
+  color: PropTypes.string,
+  /**
+   * Disables button click
+   */
+  disabled: PropTypes.bool, // eslint-disable-line
+  /**
+   * Adds spinner
+   */
+  isWaiting: PropTypes.bool,
+  /**
+   * onClick callback
+   */
+  onClick: PropTypes.func
+};
+
 Button.defaultProps = {
   color: "default",
   component: "button",
@@ -92,16 +117,4 @@ Button.defaultProps = {
   variant: "text"
 };
 
-Button.propTypes = {
-  children: PropTypes.node,
-  classes: PropTypes.object,
-  color: PropTypes.string,
-  disabled: PropTypes.bool, // eslint-disable-line
-  isWaiting: PropTypes.bool,
-  onClick: PropTypes.func
-};
-
-// withStyles() will work after 'theme' is defined in this context
-// export default withStyles(styles, { name: "RuiButton" })(Button);
 export default Button;
-

--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -49,7 +49,7 @@ function Button(props) {
 
   const classes = useStyles();
 
-  if (color === "danger") {
+  if (color === "error") {
     return (
       <MuiButton
         classes={{

--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -83,38 +83,25 @@ Button.propTypes = {
    */
   children: PropTypes.node,
   /**
-   * Classes
+   * CSS Classes
    */
   classes: PropTypes.object,
   /**
-   * Color: "danger", "primary", "secondary"
+   * Options: `default` | `inherit` | `primary` | `secondary` | `danger`
    */
-  color: PropTypes.string,
+  color: PropTypes.enum,
   /**
-   * Disables button click
+   * If `true`, the button will be disabled.
    */
   disabled: PropTypes.bool, // eslint-disable-line
   /**
-   * Adds spinner
+   * If `true`, the CircularProgress will be displayed.
    */
   isWaiting: PropTypes.bool,
   /**
    * onClick callback
    */
   onClick: PropTypes.func
-};
-
-Button.defaultProps = {
-  color: "default",
-  component: "button",
-  disabled: false,
-  disableFocusRipple: false,
-  disableRipple: false,
-  fullWidth: false,
-  href: null,
-  mini: false,
-  size: "medium",
-  variant: "text"
 };
 
 export default Button;

--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -89,9 +89,13 @@ Button.propTypes = {
   /**
    * Options: `default` | `inherit` | `primary` | `secondary` | `danger`
    */
-  color: PropTypes.enum,
+  color: PropTypes.string,
   /**
-   * If `true`, the CircularProgress will be displayed.
+   * If `true`, the button will be disabled.
+   */
+  disabled: PropTypes.bool, // eslint-disable-line
+  /**
+   * If `true`, the CircularProgress will be displayed and the button will be disabled.
    */
   isWaiting: PropTypes.bool,
   /**

--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -36,17 +36,10 @@ const useStyles = makeStyles((theme) => ({
 /**
  * @name Button
  * @param {Object} props Component props
- * @returns {React.Component} returns a React component
+ * @returns {React.Component} A React component
  */
-function Button(props) {
-  const {
-    children,
-    color,
-    disabled,
-    isWaiting,
-    ...otherProps
-  } = props;
-
+const Button = React.forwardRef(function Button(props, ref) {
+  const { children, color, disabled, isWaiting, ...otherProps } = props;
   const classes = useStyles();
 
   if (color === "error") {
@@ -58,6 +51,7 @@ function Button(props) {
         }}
         color="primary"
         disabled={disabled || isWaiting}
+        ref={ref}
         {...otherProps}
       >
         {children}
@@ -70,13 +64,14 @@ function Button(props) {
     <MuiButton
       color={color}
       disabled={disabled || isWaiting}
+      ref={ref}
       {...otherProps}
     >
       {children}
       {isWaiting && <CircularProgress size={16} className={classes.buttonProgress} />}
     </MuiButton>
   );
-}
+});
 
 Button.propTypes = {
   /**

--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -7,7 +7,7 @@ import { CircularProgress, Button as MuiButton, makeStyles } from "@material-ui/
 
 const useStyles = makeStyles((theme) => ({
   buttonProgress: {
-    marginLeft: theme.spacing.unit
+    marginLeft: theme.spacing()
   },
   containedPrimary: {
     "color": theme.palette.primary.contrastText,

--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -1,8 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import CircularProgress from "@material-ui/core/CircularProgress";
-import MuiButton from "@material-ui/core/Button";
-import makeStyles from "@material-ui/core/styles/makeStyles";
+import { MuiButton, CircularProgress, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
   buttonProgress: {

--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -91,10 +91,6 @@ Button.propTypes = {
    */
   color: PropTypes.enum,
   /**
-   * If `true`, the button will be disabled.
-   */
-  disabled: PropTypes.bool, // eslint-disable-line
-  /**
    * If `true`, the CircularProgress will be displayed.
    */
   isWaiting: PropTypes.bool,

--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -1,6 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { MuiButton, CircularProgress, makeStyles } from "@material-ui/core";
+// import CircularProgress from "@material-ui/core/CircularProgress";
+// import MuiButton from "@material-ui/core/Button";
+// import makeStyles from "@material-ui/core/styles/makeStyles";
+import { CircularProgress, Button as MuiButton, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
   buttonProgress: {

--- a/package/src/components/Button/Button.md
+++ b/package/src/components/Button/Button.md
@@ -1,11 +1,13 @@
 ### Overview
 
-Buttons are used to enable a user to take an action. Buttons should clearly and simply communicate the action that will happen when they are pressed.
+The Catalyst Button inherits from the Material-UI [Button component](https://material-ui.com/components/buttons/). Refer to tne Material-UI [Button API docs](https://material-ui.com/api/button/) for more information. 
 
 ### Usage
 
 
-#### Default button
+#### Default Catalyst button
+
+This is what a button with all the default prop options looks like:
 
 ```jsx
 <div style={{ display: "flex" }}>
@@ -15,7 +17,9 @@ Buttons are used to enable a user to take an action. Buttons should clearly and 
 </div>
 ```
 
-#### Variants
+It's a button with `variant` set to `text`, `size` set to `medium`, `color` set to `default`.
+
+#### Material UI options
 
 - **Solid button**: The solid button is used for a primary action in a modal, card, large view and generally throughout.
 - **Outline button**: The outline button is used for a secondary or dismissive action. The outline button should be paired with the solid button in cases such as dismissing a modal or canceling an action.
@@ -34,18 +38,7 @@ Buttons are used to enable a user to take an action. Buttons should clearly and 
 </div>
 ```
 
-- **Danger button**: The danger button is used for a destructive action that is difficult to recover from such as deleting information. The danger button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the danger button.
-
-```jsx
-<div style={{ display: "flex" }}>
-  <div style={{ marginRight: "1rem" }}>
-    <Button variant="contained" color="danger">Danger</Button>
-  </div>
-</div>
-```
-
-- **isWaiting**: Docs go here.
-- **Disabled**: Docs go here.
+- **Disabled**: Docs go here. When do you use this button in Catalyst?
 
 ```jsx
 <div style={{ display: "flex" }}>
@@ -58,10 +51,39 @@ Buttons are used to enable a user to take an action. Buttons should clearly and 
 </div>
 ```
 
-- **Full Width**: Docs go here.
+- **Full Width**: Docs go here. When do you use this button in Catalyst?
 
 ```jsx
-<div style={{ display: "flex" }}>
+<div style={{ display: "block" }}>
   <Button variant="contained" fullWidth>FullWidth</Button>
 </div>
 ```
+
+#### Catalyst-custom buttons
+
+- **Danger button**: The danger button is used for a destructive action that is difficult to recover from such as deleting information. The danger button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the danger button.
+
+```jsx
+<div style={{ display: "flex" }}>
+  <div style={{ marginRight: "1rem" }}>
+    <Button variant="contained" color="danger">Danger - Contained</Button>
+  </div>
+  <div style={{ marginRight: "1rem" }}>
+    <Button variant="outlined" color="danger">Danger - Outlined</Button>
+  </div>
+</div>
+```
+
+- **isWaiting**: Docs go here.
+
+```jsx
+<div style={{ display: "flex" }}>
+  <div style={{ marginRight: "1rem" }}>
+    <Button variant="contained" isWaiting>isWaiting - Contained</Button>
+  </div>
+  <div style={{ marginRight: "1rem" }}>
+    <Button variant="outlined" isWaiting>isWaiting - Outlined</Button>
+  </div>
+</div>
+```
+

--- a/package/src/components/Button/Button.md
+++ b/package/src/components/Button/Button.md
@@ -21,7 +21,7 @@ It's a button with `variant` set to `text`, `size` set to `medium`, `color` set 
 
 #### Material UI options
 
-- **Solid button**: The solid button is used for a primary action in a modal, card, large view and generally throughout.
+- **Solid (Contained) button**: The solid button is used for a primary action in a modal, card, large view and generally throughout.
 - **Outline button**: The outline button is used for a secondary or dismissive action. The outline button should be paired with the solid button in cases such as dismissing a modal or canceling an action.
 
 ```jsx
@@ -38,17 +38,17 @@ It's a button with `variant` set to `text`, `size` set to `medium`, `color` set 
 </div>
 ```
 
-- **Disabled**: Docs go here. When do you use this button in Catalyst?
+- **Disabled**:
 
 ```jsx
 <div style={{ display: "flex" }}>
   <div style={{ marginRight: "1rem" }}>
-    <Button variant="contained" isWaiting>isWaiting</Button>
+    <Button variant="contained" disabled>Disabled</Button>
   </div>
 </div>
 ```
 
-- **Full Width**: Docs go here. When do you use this button in Catalyst?
+- **Full Width**:
 
 ```jsx
 <div style={{ display: "block" }}>
@@ -58,20 +58,20 @@ It's a button with `variant` set to `text`, `size` set to `medium`, `color` set 
 
 #### Catalyst-custom buttons
 
-- **Danger button**: The danger button is used for a destructive action that is difficult to recover from such as deleting information. The danger button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the danger button.
+- **Error button**: The error button is used for a destructive action that is difficult to recover from such as deleting information. The danger button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the danger button.
 
 ```jsx
 <div style={{ display: "flex" }}>
   <div style={{ marginRight: "1rem" }}>
-    <Button variant="contained" color="danger">Danger - Contained</Button>
+    <Button variant="contained" color="error">Error - Contained</Button>
   </div>
   <div style={{ marginRight: "1rem" }}>
-    <Button variant="outlined" color="danger">Danger - Outlined</Button>
+    <Button variant="outlined" color="error">Error - Outlined</Button>
   </div>
 </div>
 ```
 
-- **isWaiting**: Docs go here.
+- **isWaiting**: The `isWaiting` prop combines `disabled` with a CircularProgress animation.
 
 ```jsx
 <div style={{ display: "flex" }}>
@@ -83,4 +83,3 @@ It's a button with `variant` set to `text`, `size` set to `medium`, `color` set 
   </div>
 </div>
 ```
-

--- a/package/src/components/Button/Button.md
+++ b/package/src/components/Button/Button.md
@@ -1,6 +1,6 @@
 ### Overview
 
-The Catalyst Button inherits from the Material-UI [Button component](https://material-ui.com/components/buttons/). Refer to tne Material-UI [Button API docs](https://material-ui.com/api/button/) for more information. 
+The Catalyst Button inherits from the Material-UI [Button component](https://material-ui.com/components/buttons/). Refer to the Material-UI [Button API docs](https://material-ui.com/api/button/) for more information. 
 
 ### Usage
 

--- a/package/src/components/Button/Button.md
+++ b/package/src/components/Button/Button.md
@@ -45,9 +45,6 @@ It's a button with `variant` set to `text`, `size` set to `medium`, `color` set 
   <div style={{ marginRight: "1rem" }}>
     <Button variant="contained" isWaiting>isWaiting</Button>
   </div>
-  <div style={{ marginRight: "1rem" }}>
-    <Button variant="outlined" disabled>Disabled</Button>
-  </div>
 </div>
 ```
 

--- a/package/src/components/Button/Button.md
+++ b/package/src/components/Button/Button.md
@@ -46,7 +46,7 @@ It's a button with `variant` set to `text`, `size` set to `medium`, `color` set 
     <Button variant="contained" isWaiting>isWaiting</Button>
   </div>
   <div style={{ marginRight: "1rem" }}>
-    <Button variant="outlined" Disabled>Disabled</Button>
+    <Button variant="outlined" disabled>Disabled</Button>
   </div>
 </div>
 ```

--- a/package/src/components/Button/Button.md
+++ b/package/src/components/Button/Button.md
@@ -4,18 +4,64 @@ Buttons are used to enable a user to take an action. Buttons should clearly and 
 
 ### Usage
 
-There are four types of buttons you can choose from, and which one you choose should be based on which type of action it causes.
 
-1. **Solid button**: The solid button is used for a primary action in a modal, card, large view and generally throughout.
-1. **Outline button**: The outline button is used for a secondary or dismissive action. The outline button should be paired with the solid button in cases such as dismissing a modal or canceling an action.
-1. **Danger button**: The danger button is used for a destructive action that is difficult to recover from such as deleting information. The danger button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the danger button.
-1. **Important button**: The important button is used when there needs to be particular importance put on an action or in a view where there are multiple actions and more emphasis needs to be drawn to specific or most common action in a view.
+#### Default button
 
-```jsx noeditor
+```jsx
 <div style={{ display: "flex" }}>
   <div style={{ marginRight: "1rem" }}>
-    <Button title="Default" className="myBtn">Default</Button>
+    <Button>Text-only</Button>
   </div>
 </div>
 ```
 
+#### Variants
+
+- **Solid button**: The solid button is used for a primary action in a modal, card, large view and generally throughout.
+- **Outline button**: The outline button is used for a secondary or dismissive action. The outline button should be paired with the solid button in cases such as dismissing a modal or canceling an action.
+
+```jsx
+<div style={{ display: "flex" }}>
+  <div style={{ marginRight: "1rem" }}>
+    <Button>Text-only</Button>
+  </div>
+  <div style={{ marginRight: "1rem" }}>
+    <Button variant="contained">Solid</Button>
+  </div>
+  <div style={{ marginRight: "1rem" }}>
+    <Button variant="outlined">Outlined</Button>
+  </div>
+</div>
+```
+
+- **Danger button**: The danger button is used for a destructive action that is difficult to recover from such as deleting information. The danger button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the danger button.
+
+```jsx
+<div style={{ display: "flex" }}>
+  <div style={{ marginRight: "1rem" }}>
+    <Button variant="contained" color="danger">Danger</Button>
+  </div>
+</div>
+```
+
+- **isWaiting**: Docs go here.
+- **Disabled**: Docs go here.
+
+```jsx
+<div style={{ display: "flex" }}>
+  <div style={{ marginRight: "1rem" }}>
+    <Button variant="contained" isWaiting>isWaiting</Button>
+  </div>
+  <div style={{ marginRight: "1rem" }}>
+    <Button variant="outlined" Disabled>Disabled</Button>
+  </div>
+</div>
+```
+
+- **Full Width**: Docs go here.
+
+```jsx
+<div style={{ display: "flex" }}>
+  <Button variant="contained" fullWidth>FullWidth</Button>
+</div>
+```

--- a/package/src/components/Button/Button.md
+++ b/package/src/components/Button/Button.md
@@ -58,7 +58,7 @@ It's a button with `variant` set to `text`, `size` set to `medium`, `color` set 
 
 #### Catalyst-custom buttons
 
-- **Error button**: The error button is used for a destructive action that is difficult to recover from such as deleting information. The danger button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the danger button.
+- **Error button**: The error button is used for a destructive action that is difficult to recover from such as deleting information. The error button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the error button.
 
 ```jsx
 <div style={{ display: "flex" }}>

--- a/package/src/components/Button/Button.test.js
+++ b/package/src/components/Button/Button.test.js
@@ -1,13 +1,10 @@
 import React from "react";
-import { render } from "../../tests/index.js";
+import { cleanup, render } from "../../tests/index.js";
 import Button from "./Button";
 
-test("basic snapshot - only default props", async () => {
-  const { asFragment } = await render(<Button className="myBtn">Submit</Button>);
-  expect(asFragment()).toMatchSnapshot();
-});
+afterEach(cleanup);
 
-// test("basic snapshot - with props for an Error button", async () => {
-//   const { asFragment } = render(<Button className="myBtn" variant="contained" color="danger">Submit</Button>);
-//   expect(asFragment()).toMatchSnapshot();
-// });
+test("basic snapshot - only default props", () => {
+  const component = render(<Button className="myBtn">Submit</Button>);
+  expect(component).toMatchSnapshot();
+});

--- a/package/src/components/Button/Button.test.js
+++ b/package/src/components/Button/Button.test.js
@@ -8,3 +8,13 @@ test("basic snapshot - only default props", () => {
   const { asFragment } = render(<Button className="myBtn">Submit</Button>);
   expect(asFragment()).toMatchSnapshot();
 });
+
+test("error button snapshot", () => {
+  const { asFragment } = render(<Button className="myBtn" color="error">Delete</Button>);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("isWaiting button snapshot", () => {
+  const { asFragment } = render(<Button className="myBtn" isWaiting>Upload</Button>);
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/package/src/components/Button/Button.test.js
+++ b/package/src/components/Button/Button.test.js
@@ -19,5 +19,6 @@ test("error button snapshot", () => {
 
 test("isWaiting button snapshot", () => {
   const { asFragment } = render(<Button className="myBtn" isWaiting>Upload</Button>);
+  expect(asFragment()).toBeDisabled();
   expect(asFragment()).toMatchSnapshot();
 });

--- a/package/src/components/Button/Button.test.js
+++ b/package/src/components/Button/Button.test.js
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "../../tests/index.js";
+import { render } from "../../tests/index.js";
 import Button from "./Button";
-
-afterEach(cleanup);
 
 test("basic snapshot - only default props", () => {
   const { asFragment } = render(<Button className="myBtn">Submit</Button>);

--- a/package/src/components/Button/Button.test.js
+++ b/package/src/components/Button/Button.test.js
@@ -1,10 +1,14 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import { MuiThemeProvider } from "@material-ui/core/styles";
+import { defaultTheme } from "../../theme/defaultTheme";
 import mockComponents from "../../tests/mockComponents";
 import Button from "./Button";
 
 test("basic snapshot", () => {
-  const component = renderer.create(<Button components={mockComponents} title="title" className="a b">Submit</Button>);
+  const component = renderer.create(<MuiThemeProvider theme={defaultTheme}>
+    <Button components={mockComponents} title="title" className="a b">Submit</Button>
+  </MuiThemeProvider>);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/Button/Button.test.js
+++ b/package/src/components/Button/Button.test.js
@@ -5,6 +5,6 @@ import Button from "./Button";
 afterEach(cleanup);
 
 test("basic snapshot - only default props", () => {
-  const component = render(<Button className="myBtn">Submit</Button>);
-  expect(component).toMatchSnapshot();
+  const { asFragment } = render(<Button className="myBtn">Submit</Button>);
+  expect(asFragment()).toMatchSnapshot();
 });

--- a/package/src/components/Button/Button.test.js
+++ b/package/src/components/Button/Button.test.js
@@ -3,11 +3,11 @@ import { render } from "../../tests/index.js";
 import Button from "./Button";
 
 test("basic snapshot - only default props", async () => {
-  const { asFragment } = render(<Button className="myBtn">Submit</Button>);
+  const { asFragment } = await render(<Button className="myBtn">Submit</Button>);
   expect(asFragment()).toMatchSnapshot();
 });
 
-test("basic snapshot - with props for an Error button", async () => {
-  const { asFragment } = render(<Button className="myBtn" variant="contained" color="danger">Submit</Button>);
-  expect(asFragment()).toMatchSnapshot();
-});
+// test("basic snapshot - with props for an Error button", async () => {
+//   const { asFragment } = render(<Button className="myBtn" variant="contained" color="danger">Submit</Button>);
+//   expect(asFragment()).toMatchSnapshot();
+// });

--- a/package/src/components/Button/Button.test.js
+++ b/package/src/components/Button/Button.test.js
@@ -1,16 +1,13 @@
 import React from "react";
-import renderer from "react-test-renderer";
-import { MuiThemeProvider } from "@material-ui/core/styles";
-import { defaultTheme } from "../../theme/defaultTheme";
-import mockComponents from "../../tests/mockComponents";
+import { render } from "../../tests/index.js";
 import Button from "./Button";
 
-test("basic snapshot", () => {
-  const component = renderer.create(<MuiThemeProvider theme={defaultTheme}>
-    <Button components={mockComponents} title="title" className="a b">Submit</Button>
-  </MuiThemeProvider>);
-
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+test("basic snapshot - only default props", async () => {
+  const { asFragment } = render(<Button className="myBtn">Submit</Button>);
+  expect(asFragment()).toMatchSnapshot();
 });
 
+test("basic snapshot - with props for an Error button", async () => {
+  const { asFragment } = render(<Button className="myBtn" variant="contained" color="danger">Submit</Button>);
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/package/src/components/Button/Button.test.js
+++ b/package/src/components/Button/Button.test.js
@@ -10,7 +10,12 @@ test("basic snapshot - only default props", () => {
 });
 
 test("error button snapshot", () => {
-  const { asFragment } = render(<Button className="myBtn" color="error">Delete</Button>);
+  const { asFragment } = render(<Button className="myBtn" color="error" variant="contained">Delete</Button>);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("error button snapshot", () => {
+  const { asFragment } = render(<Button className="myBtn" color="error" variant="outlined">Delete</Button>);
   expect(asFragment()).toMatchSnapshot();
 });
 

--- a/package/src/components/Button/Button.test.js
+++ b/package/src/components/Button/Button.test.js
@@ -18,7 +18,7 @@ test("error button snapshot", () => {
 });
 
 test("isWaiting button snapshot", () => {
-  const { asFragment } = render(<Button className="myBtn" isWaiting>Upload</Button>);
-  expect(asFragment()).toBeDisabled();
+  const { asFragment, getByText } = render(<Button className="myBtn" isWaiting>Upload</Button>);
+  expect(getByText("Upload")).toBeDisabled();
   expect(asFragment()).toMatchSnapshot();
 });

--- a/package/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/package/src/components/Button/__snapshots__/Button.test.js.snap
@@ -1,3 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`basic snapshot - only default props 1`] = `undefined`;
+exports[`basic snapshot - only default props 1`] = `
+<DocumentFragment>
+  <button
+    class="MuiButtonBase-root MuiButton-root myBtn MuiButton-text"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      Submit
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</DocumentFragment>
+`;

--- a/package/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/package/src/components/Button/__snapshots__/Button.test.js.snap
@@ -1,38 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`basic snapshot 1`] = `
-<button
-  className="MuiButtonBase-root MuiButton-root a b MuiButton-text"
-  components={
-    Object {
-      "Button": [Function],
-    }
-  }
-  disabled={false}
-  href={null}
-  mini={false}
-  onBlur={[Function]}
-  onDragLeave={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchEnd={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
-  tabIndex={0}
-  title="title"
-  type="button"
->
-  <span
-    className="MuiButton-label"
-  >
-    Submit
-  </span>
-  <span
-    className="MuiTouchRipple-root"
-  />
-</button>
-`;
+exports[`basic snapshot - only default props 1`] = `undefined`;

--- a/package/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/package/src/components/Button/__snapshots__/Button.test.js.snap
@@ -18,3 +18,58 @@ exports[`basic snapshot - only default props 1`] = `
   </button>
 </DocumentFragment>
 `;
+
+exports[`error button snapshot 1`] = `
+<DocumentFragment>
+  <button
+    class="MuiButtonBase-root MuiButton-root myBtn MuiButton-text MuiButton-textPrimary"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      Delete
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</DocumentFragment>
+`;
+
+exports[`isWaiting button snapshot 1`] = `
+<DocumentFragment>
+  <button
+    class="MuiButtonBase-root MuiButton-root myBtn MuiButton-text Mui-disabled Mui-disabled"
+    disabled=""
+    tabindex="-1"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      Upload
+      <div
+        class="MuiCircularProgress-root makeStyles-buttonProgress-67 MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
+        role="progressbar"
+        style="width: 16px; height: 16px;"
+      >
+        <svg
+          class="MuiCircularProgress-svg"
+          viewBox="22 22 44 44"
+        >
+          <circle
+            class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
+            cx="44"
+            cy="44"
+            fill="none"
+            r="20.2"
+            stroke-width="3.6"
+          />
+        </svg>
+      </div>
+    </span>
+  </button>
+</DocumentFragment>
+`;

--- a/package/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/package/src/components/Button/__snapshots__/Button.test.js.snap
@@ -22,7 +22,26 @@ exports[`basic snapshot - only default props 1`] = `
 exports[`error button snapshot 1`] = `
 <DocumentFragment>
   <button
-    class="MuiButtonBase-root MuiButton-root myBtn MuiButton-text MuiButton-textPrimary"
+    class="MuiButtonBase-root MuiButton-root myBtn MuiButton-contained MuiButton-containedPrimary makeStyles-containedPrimary-35"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      Delete
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</DocumentFragment>
+`;
+
+exports[`error button snapshot 2`] = `
+<DocumentFragment>
+  <button
+    class="MuiButtonBase-root MuiButton-root myBtn MuiButton-outlined MuiButton-outlinedPrimary makeStyles-outlinedPrimary-69"
     tabindex="0"
     type="button"
   >
@@ -51,7 +70,7 @@ exports[`isWaiting button snapshot 1`] = `
     >
       Upload
       <div
-        class="MuiCircularProgress-root makeStyles-buttonProgress-67 MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
+        class="MuiCircularProgress-root makeStyles-buttonProgress-100 MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
         role="progressbar"
         style="width: 16px; height: 16px;"
       >

--- a/package/src/components/ConfirmDialog/ConfirmDialog.test.js
+++ b/package/src/components/ConfirmDialog/ConfirmDialog.test.js
@@ -1,10 +1,8 @@
 import React from "react";
-import { render, fireEvent, cleanup } from "../../tests/";
+import { render, fireEvent } from "../../tests/";
 import "@testing-library/jest-dom/extend-expect";
 import Button from "../Button";
 import ConfirmDialog from "./ConfirmDialog";
-
-afterEach(cleanup);
 
 test("basic snapshot - with opening the dialog", () => {
   /* eslint-disable function-paren-newline */

--- a/package/src/components/ConfirmDialog/ConfirmDialog.test.js
+++ b/package/src/components/ConfirmDialog/ConfirmDialog.test.js
@@ -16,6 +16,7 @@ test("basic snapshot - with opening the dialog", () => {
       )}
     </ConfirmDialog>);
   fireEvent.click(getByText("Open Confirm Dialog"));
+  expect(getByRole("dialog")).toBeInTheDocument();
   expect(getByRole("dialog")).toHaveTextContent("Are you sure you want to do that?");
   expect(getByRole("dialog")).toHaveTextContent("Are you sure?");
   expect(getByRole("dialog")).toHaveTextContent("OK");

--- a/package/src/components/ConfirmDialog/ConfirmDialog.test.js
+++ b/package/src/components/ConfirmDialog/ConfirmDialog.test.js
@@ -1,10 +1,14 @@
 import React from "react";
-import renderer from "react-test-renderer";
+import { render, fireEvent, cleanup } from "../../tests/";
+import "@testing-library/jest-dom/extend-expect";
 import Button from "../Button";
 import ConfirmDialog from "./ConfirmDialog";
 
-test("basic snapshot", () => {
-  const component = renderer.create((
+afterEach(cleanup);
+
+test("basic snapshot - with opening the dialog", () => {
+  /* eslint-disable function-paren-newline */
+  const { asFragment, getByText, getByRole } = render(
     <ConfirmDialog
       title="Are you sure?"
       message="Are you sure you want to do that?"
@@ -12,9 +16,12 @@ test("basic snapshot", () => {
       {({ openDialog }) => (
         <Button color="primary" onClick={openDialog} variant="contained">Open Confirm Dialog</Button>
       )}
-    </ConfirmDialog>
-  ));
-
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+    </ConfirmDialog>);
+  fireEvent.click(getByText("Open Confirm Dialog"));
+  expect(getByRole("dialog")).toHaveTextContent("Are you sure you want to do that?");
+  expect(getByRole("dialog")).toHaveTextContent("Are you sure?");
+  expect(getByRole("dialog")).toHaveTextContent("OK");
+  expect(getByRole("dialog")).toHaveTextContent("Cancel");
+  expect(getByRole("dialog")).toMatchSnapshot();
+  expect(asFragment()).toMatchSnapshot();
 });

--- a/package/src/components/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
+++ b/package/src/components/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
@@ -1,33 +1,105 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`basic snapshot 1`] = `
-<button
-  className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-  disabled={false}
-  href={null}
-  mini={false}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onDragLeave={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchEnd={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
-  tabIndex={0}
-  type="button"
+exports[`basic snapshot - with opening the dialog 1`] = `
+<div
+  aria-labelledby="confirm-action-dialog-title"
+  class="MuiDialog-root"
+  role="dialog"
+  style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px;"
 >
-  <span
-    className="MuiButton-label"
-  >
-    Open Confirm Dialog
-  </span>
-  <span
-    className="MuiTouchRipple-root"
+  <div
+    aria-hidden="true"
+    class="MuiBackdrop-root"
+    style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
   />
-</button>
+  <div
+    data-test="sentinelStart"
+    tabindex="0"
+  />
+  <div
+    class="MuiDialog-container MuiDialog-scrollPaper"
+    role="document"
+    style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    tabindex="-1"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth MuiPaper-rounded"
+    >
+      <div
+        class="MuiDialogTitle-root"
+        id="confirm-action-dialog-title"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          Are you sure?
+        </h2>
+      </div>
+      <div
+        class="MuiDialogContent-root"
+      >
+        <p
+          class="MuiTypography-root MuiDialogContentText-root MuiTypography-body1 MuiTypography-colorInherit"
+        >
+          Are you sure you want to do that?
+        </p>
+      </div>
+      <div
+        class="MuiDialogActions-root MuiDialogActions-spacing"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            Cancel
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            OK
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    data-test="sentinelEnd"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`basic snapshot - with opening the dialog 2`] = `
+<DocumentFragment>
+  <button
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      Open Confirm Dialog
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</DocumentFragment>
 `;

--- a/package/src/components/DialogTitle/DialogTitle.test.js
+++ b/package/src/components/DialogTitle/DialogTitle.test.js
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "../../tests/index.js";
+import { render } from "../../tests/index.js";
 import DialogTitle from "./DialogTitle";
-
-afterEach(cleanup);
 
 test("basic snapshot - only default props", () => {
   const { asFragment } = render(<DialogTitle>Archive 24 products?</DialogTitle>);

--- a/package/src/components/DialogTitle/DialogTitle.test.js
+++ b/package/src/components/DialogTitle/DialogTitle.test.js
@@ -1,12 +1,10 @@
 import React from "react";
-import renderer from "react-test-renderer";
+import { cleanup, render } from "../../tests/index.js";
 import DialogTitle from "./DialogTitle";
 
-test("basic snapshot", () => {
-  const component = renderer.create((
-    <DialogTitle>Archive 24 products?</DialogTitle>
-  ));
+afterEach(cleanup);
 
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+test("basic snapshot - only default props", () => {
+  const { asFragment } = render(<DialogTitle>Archive 24 products?</DialogTitle>);
+  expect(asFragment()).toMatchSnapshot();
 });

--- a/package/src/components/DialogTitle/__snapshots__/DialogTitle.test.js.snap
+++ b/package/src/components/DialogTitle/__snapshots__/DialogTitle.test.js.snap
@@ -1,13 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`basic snapshot 1`] = `
-<div
-  className="MuiDialogTitle-root"
->
-  <h2
-    className="MuiTypography-root MuiTypography-h4"
+exports[`basic snapshot - only default props 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiDialogTitle-root"
   >
-    Archive 24 products?
-  </h2>
-</div>
+    <h2
+      class="MuiTypography-root MuiTypography-h4"
+    >
+      Archive 24 products?
+    </h2>
+  </div>
+</DocumentFragment>
 `;

--- a/package/src/setupTests.js
+++ b/package/src/setupTests.js
@@ -1,4 +1,0 @@
-import { configure } from "enzyme";
-import Adapter from "enzyme-adapter-react-16";
-
-configure({ adapter: new Adapter() });

--- a/package/src/setupTests.js
+++ b/package/src/setupTests.js
@@ -1,0 +1,5 @@
+// add some helpful assertions
+import "@testing-library/jest-dom/extend-expect";
+
+// this is basically: afterEach(cleanup)
+import "@testing-library/react/cleanup-after-each";

--- a/package/src/tests/index.js
+++ b/package/src/tests/index.js
@@ -1,0 +1,35 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { render } from "react-testing-library";
+import { ThemeProvider } from "@material-ui/styles";
+import { defaultTheme } from "../../theme/defaultTheme";
+
+/**
+ * Component that wraps components with mock providers during testing.
+ * @return {Component} - Component wrapped with mock providers
+ */
+const TestProviders = ({ children }) => (
+  <ThemeProvider theme={defaultTheme}>
+    {children}
+  </ThemeProvider>
+);
+
+TestProviders.propTypes = {
+  /** React Component */
+  children: PropTypes.element.isRequired,
+  /** Material-UI theme object */
+  theme: PropTypes.object
+};
+
+/**
+ * Custom test renderer that wraps all components with the appropriate mock providers.
+ * @param {Component} component - React component to render.
+ * @param {Object} options - Options.
+ * @return {Object} - @see {@link https://testing-library.com/docs/react-testing-library/api#render-result|react-testing-library}
+ */
+const renderWithProviders = async (component, options) => {
+  render({ wrapper: TestProviders, ...options });
+};
+
+export * from "react-testing-library";
+export { renderWithProviders as render };

--- a/package/src/tests/index.js
+++ b/package/src/tests/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { render } from "@testing-library/react";
-import { ThemeProvider } from "@material-ui/styles";
+import { MuiThemeProvider } from "@material-ui/styles";
 import defaultTheme from "../theme/defaultTheme";
 
 /**
@@ -9,9 +9,9 @@ import defaultTheme from "../theme/defaultTheme";
  * @return {Component} - Component wrapped with mock providers
  */
 const TestProviders = ({ children }) => (
-  <ThemeProvider theme={defaultTheme}>
+  <MuiThemeProvider theme={defaultTheme}>
     {children}
-  </ThemeProvider>
+  </MuiThemeProvider>
 );
 
 TestProviders.propTypes = {
@@ -26,7 +26,7 @@ TestProviders.propTypes = {
  * @return {Object} - @see {@link https://testing-library.com/docs/react-testing-library/api#render-result|react-testing-library}
  */
 const renderWithProviders = async (component, options) => {
-  render(component, { wrapper: ThemeProvider, ...options });
+  render(component, { wrapper: TestProviders, ...options });
 };
 
 export * from "@testing-library/react";

--- a/package/src/tests/index.js
+++ b/package/src/tests/index.js
@@ -26,7 +26,11 @@ TestProviders.propTypes = {
  * @return {Object} - @see {@link https://testing-library.com/docs/react-testing-library/api#render-result|react-testing-library}
  */
 const renderWithProviders = (component, options) => {
-  render(component, { wrapper: TestProviders, ...options });
+  /* eslint-disable react/no-multi-comp */
+  /* eslint-disable react/prop-types */
+  const Wrapper = ({ children }) => React.createElement(TestProviders, { children });
+  const renderer = render(component, { wrapper: Wrapper, ...options });
+  return renderer;
 };
 
 export * from "@testing-library/react";

--- a/package/src/tests/index.js
+++ b/package/src/tests/index.js
@@ -25,13 +25,9 @@ TestProviders.propTypes = {
  * @param {Object} options - Options.
  * @return {Object} - @see {@link https://testing-library.com/docs/react-testing-library/api#render-result|react-testing-library}
  */
-const renderWithProviders = (component, options) => {
-  /* eslint-disable react/no-multi-comp */
-  /* eslint-disable react/prop-types */
-  const Wrapper = ({ children }) => React.createElement(TestProviders, { children });
-  const renderer = render(component, { wrapper: Wrapper, ...options });
-  return renderer;
-};
+const renderWithProviders = (component, options) => (
+  render(component, { wrapper: TestProviders, ...options })
+);
 
 export * from "@testing-library/react";
 export { renderWithProviders as render };

--- a/package/src/tests/index.js
+++ b/package/src/tests/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { render } from "@testing-library/react";
-import { MuiThemeProvider } from "@material-ui/styles";
+import { MuiThemeProvider } from "@material-ui/core/styles";
 import defaultTheme from "../theme/defaultTheme";
 
 /**
@@ -25,7 +25,7 @@ TestProviders.propTypes = {
  * @param {Object} options - Options.
  * @return {Object} - @see {@link https://testing-library.com/docs/react-testing-library/api#render-result|react-testing-library}
  */
-const renderWithProviders = async (component, options) => {
+const renderWithProviders = (component, options) => {
   render(component, { wrapper: TestProviders, ...options });
 };
 

--- a/package/src/tests/index.js
+++ b/package/src/tests/index.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { render } from "react-testing-library";
+import { render } from "@testing-library/react";
 import { ThemeProvider } from "@material-ui/styles";
-import { defaultTheme } from "../../theme/defaultTheme";
+import defaultTheme from "../theme/defaultTheme";
 
 /**
  * Component that wraps components with mock providers during testing.
@@ -16,9 +16,7 @@ const TestProviders = ({ children }) => (
 
 TestProviders.propTypes = {
   /** React Component */
-  children: PropTypes.element.isRequired,
-  /** Material-UI theme object */
-  theme: PropTypes.object
+  children: PropTypes.element.isRequired
 };
 
 /**
@@ -28,8 +26,8 @@ TestProviders.propTypes = {
  * @return {Object} - @see {@link https://testing-library.com/docs/react-testing-library/api#render-result|react-testing-library}
  */
 const renderWithProviders = async (component, options) => {
-  render({ wrapper: TestProviders, ...options });
+  render(component, { wrapper: ThemeProvider, ...options });
 };
 
-export * from "react-testing-library";
+export * from "@testing-library/react";
 export { renderWithProviders as render };

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,7 +732,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.4":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
   dependencies:
@@ -1384,6 +1384,21 @@
     aria-query "3.0.0"
     pretty-format "^24.8.0"
     wait-for-expect "^1.2.0"
+
+"@testing-library/jest-dom@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-4.0.0.tgz#56eee8dd183fe14a682fda7aca6413ec4e5303d2"
+  integrity sha512-YQA/LnRRfqHV5YRauawOGgMDgq43XfyqCz3whmxIPyrfvTdjLCNyY/BseGaa48y54yb3oiRo/NZT0oXNMQdkTA==
+  dependencies:
+    "@babel/runtime" "^7.5.1"
+    chalk "^2.4.1"
+    css "^2.2.3"
+    css.escape "^1.5.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    lodash "^4.17.11"
+    pretty-format "^24.0.0"
+    redent "^3.0.0"
 
 "@testing-library/react@^8.0.6":
   version "8.0.6"
@@ -3645,6 +3660,21 @@ css-what@2.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.2.3:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -5901,6 +5931,11 @@ indent-string@^3.0.0, indent-string@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 indexes-of@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
@@ -6618,7 +6653,7 @@ jest-diff@^23.6.0:
     jest-get-type "^22.1.0"
     pretty-format "^23.6.0"
 
-jest-diff@^24.8.0:
+jest-diff@^24.0.0, jest-diff@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.8.0.tgz#146435e7d1e3ffdf293d53ff97e193f1d1546172"
   dependencies:
@@ -6774,7 +6809,7 @@ jest-matcher-utils@^23.6.0:
     jest-get-type "^22.1.0"
     pretty-format "^23.6.0"
 
-jest-matcher-utils@^24.8.0:
+jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz#2bce42204c9af12bde46f83dc839efe8be832495"
   dependencies:
@@ -8111,6 +8146,11 @@ mimic-fn@^1.0.0:
 mimic-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+
+min-indent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
+  integrity sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
 
 mini-html-webpack-plugin@^0.2.3:
   version "0.2.3"
@@ -9726,7 +9766,7 @@ pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^24.8.0:
+pretty-format@^24.0.0, pretty-format@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
   dependencies:
@@ -10428,6 +10468,14 @@ redent@^2.0.0:
   dependencies:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 redeyed@~2.1.0:
   version "2.1.1"
@@ -11480,7 +11528,7 @@ source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   dependencies:
@@ -11846,6 +11894,13 @@ strip-indent@^1.0.1:
 strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,7 +732,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.4":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
   dependencies:
@@ -1369,6 +1369,30 @@
     lodash "^4.17.4"
     read-pkg-up "^6.0.0"
 
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+
+"@testing-library/dom@^5.5.4":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.6.0.tgz#18a7c162a6a79964e731ad7b810022a28218047c"
+  integrity sha512-nAsRvQLr/b6TGNjuHMEbWXCNPLrQYnzqa/KKQZL7wBOtfptUxsa4Ah9aqkHW0ZmCSFmUDj4nFUxWPVTeMu0iCw==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    aria-query "3.0.0"
+    pretty-format "^24.8.0"
+    wait-for-expect "^1.2.0"
+
+"@testing-library/react@^8.0.6":
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-8.0.6.tgz#614340646f32027426377dc6e5895a566eeb61b5"
+  integrity sha512-/4oeS0eatnHvAf9yuxIg1/8pjl1OrtWN7SLpDFEdxFjllIAEL09xXhA88C93vvlN+8enZa+xlXJ8ecohECT6Yg==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@testing-library/dom" "^5.5.4"
+
 "@types/babel__core@^7.1.0":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.2.tgz#608c74f55928033fce18b99b213c16be4b3d114f"
@@ -1738,21 +1762,6 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^3.2.0"
 
-airbnb-prop-types@^2.13.2:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz#43147a5062dd2a4a5600e748a47b64004cc5f7fc"
-  dependencies:
-    array.prototype.find "^2.0.4"
-    function.prototype.name "^1.1.0"
-    has "^1.0.3"
-    is-regex "^1.0.4"
-    object-is "^1.0.1"
-    object.assign "^4.1.0"
-    object.entries "^1.1.0"
-    prop-types "^15.7.2"
-    prop-types-exact "^1.2.0"
-    react-is "^16.8.6"
-
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -1891,7 +1900,7 @@ argv-formatter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/argv-formatter/-/argv-formatter-1.0.0.tgz#a0ca0cbc29a5b73e836eebe1cbf6c5e0e4eb82f9"
 
-aria-query@^3.0.0:
+aria-query@3.0.0, aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
   dependencies:
@@ -1980,21 +1989,6 @@ array-unique@^0.2.1:
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
-
-array.prototype.find@^2.0.4:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.1.0.tgz#630f2eaf70a39e608ac3573e45cf8ccd0ede9ad7"
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.13.0"
-
-array.prototype.flat@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz#812db8f02cad24d3fab65dd67eabe3b8903494a4"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.10.0"
-    function-bind "^1.1.1"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -2948,17 +2942,6 @@ check-prop-types@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/check-prop-types/-/check-prop-types-1.1.2.tgz#c42df4fbdb509fbd4d8a102d113bb0ca01c21e67"
 
-cheerio@^1.0.0-rc.2:
-  version "1.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.1"
-    entities "~1.1.1"
-    htmlparser2 "^3.9.1"
-    lodash "^4.15.0"
-    parse5 "^3.0.1"
-
 chokidar@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -3634,7 +3617,7 @@ css-loader@~0.28.11:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
-css-select@^1.1.0, css-select@~1.2.0:
+css-select@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   dependencies:
@@ -3844,7 +3827,7 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
-define-properties@^1.1.2, define-properties@^1.1.3:
+define-properties@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   dependencies:
@@ -4010,10 +3993,6 @@ dir-glob@^3.0.0, dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-discontinuous-range@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
-
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -4062,7 +4041,7 @@ dom-helpers@^3.4.0:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-dom-serializer@0, dom-serializer@~0.1.1:
+dom-serializer@0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
   dependencies:
@@ -4231,7 +4210,7 @@ ensure-posix-path@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz#3c62bdb19fa4681544289edb2b382adc029179ce"
 
-entities@^1.1.1, entities@~1.1.1:
+entities@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
 
@@ -4245,53 +4224,6 @@ env-ci@^4.0.0:
 env-paths@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
-
-enzyme-adapter-react-16@~1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.8.0.tgz#7055d8e908d8d27b807cf4292244db3c815ca11d"
-  dependencies:
-    enzyme-adapter-utils "^1.10.0"
-    function.prototype.name "^1.1.0"
-    object.assign "^4.1.0"
-    object.values "^1.1.0"
-    prop-types "^15.6.2"
-    react-is "^16.7.0"
-    react-test-renderer "^16.0.0-0"
-
-enzyme-adapter-utils@^1.10.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz#96e3730d76b872f593e54ce1c51fa3a451422d93"
-  dependencies:
-    airbnb-prop-types "^2.13.2"
-    function.prototype.name "^1.1.0"
-    object.assign "^4.1.0"
-    object.fromentries "^2.0.0"
-    prop-types "^15.7.2"
-    semver "^5.6.0"
-
-enzyme@~3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.8.0.tgz#646d2d5d0798cb98fdec39afcee8a53237b47ad5"
-  dependencies:
-    array.prototype.flat "^1.2.1"
-    cheerio "^1.0.0-rc.2"
-    function.prototype.name "^1.1.0"
-    has "^1.0.3"
-    is-boolean-object "^1.0.0"
-    is-callable "^1.1.4"
-    is-number-object "^1.0.3"
-    is-string "^1.0.4"
-    is-subset "^0.1.1"
-    lodash.escape "^4.0.1"
-    lodash.isequal "^4.5.0"
-    object-inspect "^1.6.0"
-    object-is "^1.0.1"
-    object.assign "^4.1.0"
-    object.entries "^1.0.4"
-    object.values "^1.0.4"
-    raf "^3.4.0"
-    rst-selector-parser "^2.2.3"
-    string.prototype.trim "^1.1.2"
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -4309,7 +4241,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.10.0, es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.5.0, es-abstract@^1.5.1, es-abstract@^1.7.0:
+es-abstract@^1.11.0, es-abstract@^1.5.1, es-abstract@^1.7.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
   dependencies:
@@ -5189,21 +5121,13 @@ ftp@~0.3.10:
     readable-stream "1.1.x"
     xregexp "2.0.0"
 
-function-bind@^1.0.2, function-bind@^1.1.1:
+function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 function.name-polyfill@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/function.name-polyfill/-/function.name-polyfill-1.0.6.tgz#c54e37cae0a77dfcb49d47982815b0826b5c60d9"
-
-function.prototype.name@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
-  dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    is-callable "^1.1.3"
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
@@ -5737,7 +5661,7 @@ html-webpack-plugin@~2.29.0:
     pretty-error "^2.0.2"
     toposort "^1.0.0"
 
-htmlparser2@^3.3.0, htmlparser2@^3.9.1:
+htmlparser2@^3.3.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   dependencies:
@@ -6199,10 +6123,6 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-boolean-object@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
-
 is-buffer@^1.0.2, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -6211,7 +6131,7 @@ is-buffer@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
 
-is-callable@^1.1.3, is-callable@^1.1.4:
+is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
 
@@ -6362,10 +6282,6 @@ is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
 
-is-number-object@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
-
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -6475,10 +6391,6 @@ is-root@2.0.0:
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-
-is-string@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
 
 is-subset@^0.1.1:
   version "0.1.1"
@@ -7731,10 +7643,6 @@ lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
-lodash.escape@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
-
 lodash.escaperegexp@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
@@ -7743,17 +7651,9 @@ lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
 
-lodash.flattendeep@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
-
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
@@ -7816,7 +7716,7 @@ lodash.without@~4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
 
-lodash@4.17.11, lodash@4.17.14, "lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.17.11, lodash@4.17.14, "lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
 
@@ -8322,10 +8222,6 @@ moment@^2.19.2:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
 
-moo@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -8404,16 +8300,6 @@ nconf@^0.10.0:
     ini "^1.3.0"
     secure-keys "^1.0.0"
     yargs "^3.19.0"
-
-nearley@^2.7.10:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.16.0.tgz#77c297d041941d268290ec84b739d0ee297e83a7"
-  dependencies:
-    commander "^2.19.0"
-    moo "^0.4.3"
-    railroad-diagrams "^1.0.0"
-    randexp "0.4.6"
-    semver "^5.4.1"
 
 needle@^2.0.1, needle@^2.2.1:
   version "2.4.0"
@@ -8883,14 +8769,6 @@ object-hash@^1.1.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
 
-object-inspect@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
-
-object-is@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
-
 object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -8909,15 +8787,6 @@ object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
-
-object.entries@^1.0.4, object.entries@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.12.0"
-    function-bind "^1.1.1"
-    has "^1.0.3"
 
 object.fromentries@^2.0.0:
   version "2.0.0"
@@ -8947,15 +8816,6 @@ object.pick@^1.2.0, object.pick@^1.3.0:
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
   dependencies:
     isobject "^3.0.1"
-
-object.values@^1.0.4, object.values@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.0.tgz#bf6810ef5da3e5325790eaaa2be213ea84624da9"
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.12.0"
-    function-bind "^1.1.1"
-    has "^1.0.3"
 
 obuf@^1.0.0, obuf@^1.1.1, obuf@^1.1.2:
   version "1.1.2"
@@ -9348,12 +9208,6 @@ parse-passwd@^1.0.0:
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
-
-parse5@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  dependencies:
-    "@types/node" "*"
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -9939,14 +9793,6 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types-exact@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/prop-types-exact/-/prop-types-exact-1.2.0.tgz#825d6be46094663848237e3925a98c6e944e9869"
-  dependencies:
-    has "^1.0.3"
-    object.assign "^4.1.0"
-    reflect.ownkeys "^0.2.0"
-
 prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
@@ -10116,22 +9962,11 @@ qw@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
 
-raf@^3.4.0, raf@~3.4.1:
+raf@~3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   dependencies:
     performance-now "^2.1.0"
-
-railroad-diagrams@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
-
-randexp@0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
-  dependencies:
-    discontinuous-range "1.0.0"
-    ret "~0.1.10"
 
 randomatic@^3.0.0:
   version "3.1.1"
@@ -10373,7 +10208,7 @@ react-styleguidist@^9.1.11:
     webpack-dev-server "^3.2.1"
     webpack-merge "^4.2.1"
 
-react-test-renderer@^16.0.0-0, react-test-renderer@~16.8.6:
+react-test-renderer@~16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.8.6.tgz#188d8029b8c39c786f998aa3efd3ffe7642d5ba1"
   dependencies:
@@ -10613,10 +10448,6 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
-
-reflect.ownkeys@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
 
 regenerate-unicode-properties@^8.0.2:
   version "8.1.0"
@@ -10982,13 +10813,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
-
-rst-selector-parser@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
-  dependencies:
-    lodash.flattendeep "^4.4.0"
-    nearley "^2.7.10"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -11930,14 +11754,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string.prototype.trim@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.5.0"
-    function-bind "^1.0.2"
-
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
@@ -12832,6 +12648,11 @@ w3c-hr-time@^1.0.1:
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+wait-for-expect@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.2.0.tgz#fdab6a26e87d2039101db88bff3d8158e5c3e13f"
+  integrity sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==
 
 walk-sync@^0.3.2:
   version "0.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10169,7 +10169,7 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
-react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
 
@@ -10247,15 +10247,6 @@ react-styleguidist@^9.1.11:
     unist-util-visit "^1.4.0"
     webpack-dev-server "^3.2.1"
     webpack-merge "^4.2.1"
-
-react-test-renderer@~16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.8.6.tgz#188d8029b8c39c786f998aa3efd3ffe7642d5ba1"
-  dependencies:
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    react-is "^16.8.6"
-    scheduler "^0.13.6"
 
 react-transition-group@^4.0.0:
   version "4.2.1"


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Resolves #29 - themes
Resolves #16 - docs
Resolves #19 - tests
Impact: **major**  
Type: **bugfix|style|docs|tests**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Changes

### Component: Button
- add mui theme to Button
- renames danger button to Error button

### Tests
- remove Enzyme, React Test Renderer
- add https://testing-library.com/docs/react-testing-library, and Jest-dom
- create `renderWithProviders` to add mui theme provider to test renderer

### Packages
- adds `react-testing-library`
- adds `jest-dom`
- removes `enzyme`
- removes `react-test-renderer`

### Templates
- Updates test template to use react-testing-lib and jest-dom.

## Breaking changes
- Danger button is now Error button. Change all `color="danger"` to `color="error"`

## Testing/Reviewing
1. Button docs: https://deploy-preview-32--heuristic-perlman-0ef024.netlify.com/#/Base%20Components/Actions/Button
1. Test ConfirmDialog test
1. Test the tests! Make sure the snapshots reflect reality.
1. Make sure I did not mess up the Babel configs.
1. Make sure the component templates test looks okay.