### PR TITLE
chore: use glob pattern to remove files in prebuild

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -13,7 +13,7 @@
   "private": false,
   "sideEffects": false,
   "scripts": {
-    "prebuild": "rimraf dist && rimraf dist-modules-temp && node ./scripts/prebuild.js",
+    "prebuild": "rimraf dist/**/* && rimraf dist-modules-temp && node ./scripts/prebuild.js",
     "build": "npm run build:common && npm run build:modules",
     "build:common": "BABEL_ENV=production babel --root-mode upward src --out-dir dist",
     "build:modules": "BABEL_ENV=production BABEL_MODULES=1 babel --root-mode upward src --out-dir dist-modules-temp",


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Issue

This fixes issues with using docker volumes to link the `dist` folder into a project like Reaction.

## Breaking changes
none

## Testing
1. Follow the steps here to link the `package/dist` directory into the `Reaction Admin`: https://catalyst.reactioncommerce.com/#/Introduction/Developing%20Locally%20Inside%20Another%20Project
2. Change things in catalyst components and run `yarn build` multiple times from the package directory.
3. Your Reaction Admin should reload with the new changes