### PR TITLE
feat: collapsible menus

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -140,29 +140,12 @@ module.exports = {
       }
     },
     ComponentsList: {
-      item: {
-        "color": "#062a4e",
-        "fontSize": 14,
-        "& > a": {
-          display: "inline",
-          fontFamily: "PostGrotesk-Bold !important",
-          letterSpacing: "0.6px !important",
-          textDecoration: "none !important"
-        }
+      heading: {
+        fontFamily: "PostGrotesk-Bold !important"
       },
-      isChild: {
-        "& > a": {
-          fontFamily: "PostGrotesk-Regular !important",
-          letterSpacing: "0.4px !important"
-        },
-        "& > a:hover": {
-          cursor: "pointer",
-          backgroundImage: "linear-gradient(#f7fdff 50%, #a7edff 50%) !important",
-          backgroundRepeat: "repeat-x !important",
-          backgroundSize: "8px 4px !important",
-          backgroundPositionY: "0.9em !important",
-          transition: "background-image .3s ease-in"
-        }
+      item: {
+        color: "#062a4e",
+        fontSize: 14
       }
     },
     Heading: {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -309,7 +309,8 @@ module.exports = {
     }
   },
   styleguideComponents: {
-    Wrapper: path.join(__dirname, "styleguide/src/components/Wrapper")
+    Wrapper: path.join(__dirname, "styleguide/src/components/Wrapper"),
+    ComponentsListRenderer: path.join(__dirname, "styleguide/src/components/ComponentsListRenderer")
   },
   sections: [
     {

--- a/styleguide/src/components/ComponentsListRenderer.js
+++ b/styleguide/src/components/ComponentsListRenderer.js
@@ -1,0 +1,106 @@
+import React, { Fragment, useState } from "react";
+import PropTypes from "prop-types";
+import cx from "clsx";
+import Styled from "rsg-components/Styled";
+import { getHash } from "react-styleguidist/lib/client/utils/handleHash";
+import ListItem from "@material-ui/core/ListItem";
+import Collapse from "@material-ui/core/Collapse";
+
+const styles = ({ color, fontSize }) => ({
+  item: {
+    "display": "block !important",
+    "cursor": "pointer",
+    "fontSize": fontSize.base,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "&:hover > span": {
+      cursor: "pointer",
+      backgroundImage: "linear-gradient(#f7fdff 50%, #a7edff 50%) !important",
+      backgroundRepeat: "repeat-x !important",
+      backgroundSize: "8px 4px !important",
+      backgroundPositionY: "0.9em !important"
+    }
+  },
+  text: {
+    color: color.link,
+    fontSize: 14,
+    letterSpacing: "0.4px !important"
+  },
+  heading: {
+    color: color.link,
+    letterSpacing: "0.6px !important",
+    textDecoration: "none !important"
+  },
+  isSelected: {
+    fontWeight: "bold",
+    display: "inline !important",
+    backgroundImage: "linear-gradient(#f7fdff 50%, #a7edff 50%) !important",
+    backgroundRepeat: "repeat-x !important",
+    backgroundSize: "8px 4px !important",
+    backgroundPositionY: "0.9em !important"
+  },
+  child: {
+    backgroundColor: "green"
+  }
+});
+
+/**
+ * Component List renderer
+ * @param {Object} param Component props
+ * @returns {node} React element
+ */
+export function ComponentsListRenderer({ classes, items: itemsProp }) {
+  const items = itemsProp.filter((item) => item.visibleName);
+
+  if (!items.length) {
+    return null;
+  }
+
+  const windowHash = window.location.pathname + getHash(window.location.hash);
+  return items.map(({ heading, visibleName, href, content, shouldOpenInNewTab, sectionDepth }) => {
+    const depth = sectionDepth || 0;
+    const [isOpen, setIsOpen] = useState(depth < 2 || windowHash.includes(visibleName));
+    const isItemSelected = href.endsWith(encodeURI(windowHash));
+
+    return (
+      <Fragment>
+        <ListItem
+          className={classes.item}
+          target={shouldOpenInNewTab ? "_blank" : undefined}
+          component="a"
+          href={href}
+          key={href}
+          disablePadding
+          onClick={() => {
+            setIsOpen(!isOpen);
+          }}
+          style={{
+            paddingTop: 4,
+            paddingBottom: 4,
+            paddingLeft: (Math.abs(depth - 2) * 16) + 16
+          }}
+        >
+          <span
+            className={cx(classes.text, {
+              [classes.heading]: heading,
+              [classes.isSelected]: isItemSelected
+            })}
+          >
+            {visibleName}
+          </span>
+        </ListItem>
+
+        <Collapse in={isOpen}>
+          {content}
+        </Collapse>
+      </Fragment>
+    );
+  });
+}
+
+ComponentsListRenderer.propTypes = {
+  classes: PropTypes.object.isRequired,
+  items: PropTypes.array.isRequired
+};
+
+export default Styled(styles)(ComponentsListRenderer);

--- a/styleguide/src/components/ComponentsListRenderer.js
+++ b/styleguide/src/components/ComponentsListRenderer.js
@@ -62,39 +62,35 @@ export function ComponentsListRenderer({ classes, items: itemsProp }) {
     const [isOpen, setIsOpen] = useState(depth < 2 || windowHash.includes(visibleName));
     const isItemSelected = href.endsWith(encodeURI(windowHash));
 
-    return (
-      <Fragment>
-        <ListItem
-          className={classes.item}
-          target={shouldOpenInNewTab ? "_blank" : undefined}
-          component="a"
-          href={href}
-          key={href}
-          disablePadding
-          onClick={() => {
-            setIsOpen(!isOpen);
-          }}
-          style={{
-            paddingTop: 4,
-            paddingBottom: 4,
-            paddingLeft: (Math.abs(depth - 2) * 16) + 16
-          }}
+    return [
+      <ListItem
+        className={classes.item}
+        target={shouldOpenInNewTab ? "_blank" : undefined}
+        component="a"
+        href={href}
+        key={href}
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+        style={{
+          paddingTop: 4,
+          paddingBottom: 4,
+          paddingLeft: (Math.abs(depth - 2) * 16) + 16
+        }}
+      >
+        <span
+          className={cx(classes.text, {
+            [classes.heading]: heading,
+            [classes.isSelected]: isItemSelected
+          })}
         >
-          <span
-            className={cx(classes.text, {
-              [classes.heading]: heading,
-              [classes.isSelected]: isItemSelected
-            })}
-          >
-            {visibleName}
-          </span>
-        </ListItem>
-
-        <Collapse in={isOpen}>
-          {content}
-        </Collapse>
-      </Fragment>
-    );
+          {visibleName}
+        </span>
+      </ListItem>,
+      <Collapse in={isOpen} key={`collapse:${href}`}>
+        {content}
+      </Collapse>
+    ];
   });
 }
 

--- a/styleguide/src/components/ComponentsListRenderer.js
+++ b/styleguide/src/components/ComponentsListRenderer.js
@@ -1,10 +1,9 @@
-import React, { Fragment, useState } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import cx from "clsx";
 import Styled from "rsg-components/Styled";
 import { getHash } from "react-styleguidist/lib/client/utils/handleHash";
-import ListItem from "@material-ui/core/ListItem";
-import Collapse from "@material-ui/core/Collapse";
+import { Collapse, ListItem } from "@material-ui/core";
 
 const styles = ({ color, fontSize }) => ({
   item: {


### PR DESCRIPTION
Resolves #15 
Impact: **minor**  
Type: **feature**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component

- Make the menu sections collapsible.
- The top-level sections are collapsed by default.
- All sub-sections are expanded by default. These include "Actions" and "Feedback" under "Base Components"

## Screenshots
![image](https://user-images.githubusercontent.com/42217/61925584-d7c05b00-af21-11e9-868a-15a6494a7c50.png)


## Breaking changes

none

## Testing
1. Open the docs site and you should see all top-level menus in their collapsed state
2. Click on any menu item to expand. (if it has a page will be navigated to, we should probably remove these section pages in another PR)
3. Click on any component docs or sub-item to navigate to that doc
4. Refresh.
5. The selected item should remain selected, and the menu expanded for that sub-item
