### PR TITLE
chore: lil docs fixes

### DIFF
--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -1,8 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-// import CircularProgress from "@material-ui/core/CircularProgress";
-// import MuiButton from "@material-ui/core/Button";
-// import makeStyles from "@material-ui/core/styles/makeStyles";
 import { CircularProgress, Button as MuiButton, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
@@ -84,7 +81,7 @@ Button.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * Options: `default` | `inherit` | `primary` | `secondary` | `danger`
+   * Options: `default` | `inherit` | `primary` | `secondary` | `error`
    */
   color: PropTypes.string,
   /**

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -334,7 +334,7 @@ module.exports = {
       sectionDepth: 2
     },
     {
-      name: "Base Components",
+      name: "Catalyst Components",
       sections: [
         generateSection({
           componentNames: [

--- a/styleguide/src/sections/LocalDevelopment.md
+++ b/styleguide/src/sections/LocalDevelopment.md
@@ -1,6 +1,6 @@
-If you'd like to see your changes locally inside of another project, such as the [Reaction Operator UI](https://github.com/reactioncommerce/reaction) or the [Reaction Storefront](https://github.com/reactioncommerce/reaction-next-starterkit), it's possible to link your local version of this Component Library using the following steps:
+If you'd like to see your changes locally inside of another project, such as the [Reaction Operator UI](https://github.com/reactioncommerce/reaction) or the [Reaction Storefront](https://github.com/reactioncommerce/reaction-next-starterkit), it's possible to link your local version of Catalyst using the following steps:
 
-- `cd` into your local version of the [Reaction Component Library](https://github.com/reactioncommerce/reaction-component-library), and run the following commands:
+- `cd` into your local version of the [Catalyst](https://github.com/reactioncommerce/catalystt), and run the following commands:
 
 ```diff
 yarn install
@@ -9,7 +9,7 @@ yarn install
 yarn run build
 ```
 
-- Next, `cd` into the local version of the repository you'd like to use the local `Catalyst Library` inside. Add the following line to the `volumes:` portion of the `docker-compose.yml` file:
+- Next, `cd` into the local version of the repository you'd like to use the local `Catalyst` inside. Add the following line to the `volumes:` portion of the `docker-compose.yml` file:
 
 Inside `Reaction Storefront`:
 
@@ -31,7 +31,7 @@ volumes:
   - reaction_node_modules:/opt/reaction/src/node_modules # do not link node_modules in, and persist it between dc up runs
 + - /{Path-to-your-local-repo}/catalyst/package/dist:/opt/reaction/src/node_modules/@reactioncommerce/catalyst
 ```
-
+- Remove the `"@reactioncommerce/catalyst"` line from the project's `package.json` file. 
 - Next, run `docker-compose up -d` like normal to access the app in your browser and test it.
 
-**Be sure to remove and not commit the added line from `docker-compose.yml` when you are done testing.**
+**Be sure to remove and not commit the added line from `docker-compose.yml` and the removed line from `package.json` when you are done testing.**


### PR DESCRIPTION
#35 
- update docs for running this locally
- docs: update docs for Button
- removes the word "base" from components, requested by @rymorgan 