### PR TITLE
docs(button): change danger to error; remove comments

### DIFF
--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -1,8 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-// import CircularProgress from "@material-ui/core/CircularProgress";
-// import MuiButton from "@material-ui/core/Button";
-// import makeStyles from "@material-ui/core/styles/makeStyles";
 import { CircularProgress, Button as MuiButton, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
@@ -84,7 +81,7 @@ Button.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * Options: `default` | `inherit` | `primary` | `secondary` | `danger`
+   * Options: `default` | `inherit` | `primary` | `secondary` | `error`
    */
   color: PropTypes.string,
   /**


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Resolves #
Impact: *minor**  
Type: **docs|chore**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Button
- docs: change `danger` to `error` to reflect the code correctly
- code: delete comments

## Breaking changes
None

## Testing
1. Read the docs
