### PR TITLE
fix: make button padding match designsystem button; add isShortHeight prop

### DIFF
--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -4,10 +4,10 @@ import { CircularProgress, Button as MuiButton, makeStyles } from "@material-ui/
 
 const useStyles = makeStyles((theme) => ({
   normalPadding: {
-    "padding": "10px 20px"
+    padding: "10px 20px"
   },
   shortPadding: {
-    "padding": "5px 20px"
+    padding: "5px 20px"
   },
   buttonProgress: {
     marginLeft: theme.spacing()
@@ -46,7 +46,7 @@ const Button = React.forwardRef(function Button(props, ref) {
   const { children, color, disabled, isWaiting, isShortHeight, ...otherProps } = props;
   const classes = useStyles();
 
-  let componentClasses = {};
+  const componentClasses = {};
   if (isShortHeight) {
     componentClasses.root = classes.shortPadding;
   } else {
@@ -103,17 +103,17 @@ Button.propTypes = {
    */
   disabled: PropTypes.bool, // eslint-disable-line
   /**
+   * Use short vertical padding? (5px instead of 10px)
+   */
+  isShortHeight: PropTypes.bool,
+  /**
    * If `true`, the CircularProgress will be displayed and the button will be disabled.
    */
   isWaiting: PropTypes.bool,
   /**
    * onClick callback
    */
-  onClick: PropTypes.func,
-  /**
-   * Use short vertical padding? (5px instead of 10px)
-   */
-  isShortHeight: PropTypes.bool
+  onClick: PropTypes.func
 };
 
 export default Button;

--- a/package/src/components/Button/Button.js
+++ b/package/src/components/Button/Button.js
@@ -3,6 +3,12 @@ import PropTypes from "prop-types";
 import { CircularProgress, Button as MuiButton, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
+  normalPadding: {
+    "padding": "10px 20px"
+  },
+  shortPadding: {
+    "padding": "5px 20px"
+  },
   buttonProgress: {
     marginLeft: theme.spacing()
   },
@@ -37,16 +43,23 @@ const useStyles = makeStyles((theme) => ({
  * @returns {React.Component} A React component
  */
 const Button = React.forwardRef(function Button(props, ref) {
-  const { children, color, disabled, isWaiting, ...otherProps } = props;
+  const { children, color, disabled, isWaiting, isShortHeight, ...otherProps } = props;
   const classes = useStyles();
 
+  let componentClasses = {};
+  if (isShortHeight) {
+    componentClasses.root = classes.shortPadding;
+  } else {
+    componentClasses.root = classes.normalPadding;
+  }
+
   if (color === "error") {
+    componentClasses.containedPrimary = classes.containedPrimary;
+    componentClasses.outlinedPrimary = classes.outlinedPrimary;
+
     return (
       <MuiButton
-        classes={{
-          containedPrimary: classes.containedPrimary,
-          outlinedPrimary: classes.outlinedPrimary
-        }}
+        classes={componentClasses}
         color="primary"
         disabled={disabled || isWaiting}
         ref={ref}
@@ -60,6 +73,7 @@ const Button = React.forwardRef(function Button(props, ref) {
 
   return (
     <MuiButton
+      classes={componentClasses}
       color={color}
       disabled={disabled || isWaiting}
       ref={ref}
@@ -95,7 +109,11 @@ Button.propTypes = {
   /**
    * onClick callback
    */
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  /**
+   * Use short vertical padding? (5px instead of 10px)
+   */
+  isShortHeight: PropTypes.bool
 };
 
 export default Button;

--- a/package/src/components/Button/Button.md
+++ b/package/src/components/Button/Button.md
@@ -83,3 +83,16 @@ It's a button with `variant` set to `text`, `size` set to `medium`, `color` set 
   </div>
 </div>
 ```
+
+- **isShortHeight**: The `isShortHeight` prop halves the vertical padding of the button contents from 10px to 5px. This is useful for tighter spaces such as table headers.
+
+```jsx
+<div style={{ display: "flex" }}>
+  <div style={{ marginRight: "1rem" }}>
+    <Button variant="contained" isShortHeight>isShortHeight - Contained</Button>
+  </div>
+  <div style={{ marginRight: "1rem" }}>
+    <Button variant="outlined" isShortHeight>isShortHeight - Outlined</Button>
+  </div>
+</div>
+```


### PR DESCRIPTION
Resolves #n/a
Impact: **minor**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component
Button: Use 20px top and bottom padding except when isShortHeight prop is set, in which case 5px top and bottom padding are used.

## Screenshots
Old (designsystem) Button, full height, for reference:
![image](https://user-images.githubusercontent.com/492653/62398921-23898a80-b548-11e9-9c75-712c222195a5.png)

Old (designsystem) Button, short height, for reference:
![image](https://user-images.githubusercontent.com/492653/62399098-a9a5d100-b548-11e9-8e09-455ec0c8e65f.png)

New (catalyst) Button, normal height:
![image](https://user-images.githubusercontent.com/492653/62399024-719e8e00-b548-11e9-9155-6b75eda623de.png)

New (catalyst) Button, short height:
![image](https://user-images.githubusercontent.com/492653/62399049-87ac4e80-b548-11e9-81e0-d6994b2dd50d.png)

## Breaking changes
n/a

## Testing
Ensure that button dimensions and padding are correct and won't break existing design in Reaction Admin