### PR TITLE
feat(Chip): add deletable Chip, deletable Chip in small/secondary types

### DIFF
--- a/package/src/components/Chip/Chip.js
+++ b/package/src/components/Chip/Chip.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Chip as MuiChip, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
-  containedPrimary: {
+  colorPrimary: {
     color: theme.palette.primary.contrastText,
     backgroundColor: theme.palette.colors.red
   },

--- a/package/src/components/Chip/Chip.md
+++ b/package/src/components/Chip/Chip.md
@@ -15,13 +15,13 @@ const onDelete = () => { console.log("stuff") };
 <div>
   <div style={{ display: "flex" }}>
     <div style={{ marginRight: "1rem" }}>
+      <Chip color="error" label="status chip" />
+    </div>
+    <div style={{ marginRight: "1rem" }}>
       <Chip label="deletable chip" variant="default" color="primary" onDelete={onDelete} />
     </div>
     <div style={{ marginRight: "1rem" }}>
       <Chip label="small deletable chip for multiselect" variant="default" color="secondary" size="small" onDelete={onDelete} />
-    </div>
-    <div style={{ marginRight: "1rem" }}>
-      <Chip color="error" label="Order Cancelled" />
     </div>
   </div>
 </div>
@@ -38,23 +38,74 @@ const onDelete = () => { console.log("stuff") };
 Use a Deletable chip to allow users to remove an entity, like removing a Tag from a filter input. To create a Deletable chip, pass a Delete function to `onDelete`, and use the `default` variant with the `primary` color.
 
 ```jsx
-const onDelete = () => { console.log("stuff") };
-<div>
-  <Chip label="sale-fall2019.csv" variant="default" color="primary" onDelete={onDelete} />
-</div>
+function ChipsArray() {
+  const [chipData, setChipData] = React.useState([
+    { key: 0, label: 'swim-2019.csv' },
+    { key: 1, label: 'womens-2019.csv' },
+    { key: 2, label: 'mens-2019.csv' }
+  ]);
+
+  const handleDelete = chipToDelete => () => {
+    setChipData(chips => chips.filter(chip => chip.key !== chipToDelete.key));
+  };
+
+  return (
+    <div>
+      {chipData.map(data => {
+        return (
+          <Chip
+            variant="default"
+            color="primary"
+            key={data.key}
+            label={data.label}
+            onDelete={handleDelete(data)}
+            style={{marginRight: "4px"}}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+<ChipsArray/>
 ```
 
-##### Deletable chip for Selects, MultiSelects
+##### Deletable chip for MultiSelects
 
-Use a Deletable chip in components like a Select or MultiSelect to allow users to remove entities within another action. To create a Deletable chip for a Select or MultiSelect, use the `default` variant with the `secondary` color and `small` size props, along with p assing an `onDelete` function.
+Use a Deletable chip in components a MultiSelect to allow users to remove entities within another action. To create a Deletable chip for a Select or MultiSelect, use the `default` variant with the `secondary` color and `small` size props, along with p assing an `onDelete` function.
 
 ```jsx
-const onDelete = () => { console.log("stuff") };
-<div>
-  <Chip label="sale" variant="default" color="secondary" size="small" onDelete={onDelete} />
-  <Chip label="winter-specials" variant="default" color="secondary" size="small" onDelete={onDelete} />
-  <Chip label="sale-fall2019" variant="default" color="secondary" size="small" onDelete={onDelete} />
-</div>
+function ChipsArray() {
+  const [chipData, setChipData] = React.useState([
+    { key: 0, label: 'womens' },
+    { key: 1, label: 'mens' },
+    { key: 2, label: 'fall-winter-2019' }
+  ]);
+
+  const handleDelete = chipToDelete => () => {
+    setChipData(chips => chips.filter(chip => chip.key !== chipToDelete.key));
+  };
+
+  return (
+    <div>
+      {chipData.map(data => {
+        return (
+          <Chip
+            variant="default"
+            color="secondary"
+            size="small"
+            key={data.key}
+            label={data.label}
+            onDelete={handleDelete(data)}
+            style={{marginRight: "4px"}}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+<ChipsArray/>
 ```
 
 ##### Error chip

--- a/package/src/components/Chip/Chip.md
+++ b/package/src/components/Chip/Chip.md
@@ -15,7 +15,7 @@ const onDelete = () => { console.log("stuff") };
 <div>
   <div style={{ display: "flex" }}>
     <div style={{ marginRight: "1rem" }}>
-      <Chip label="deletable chip" variant="outlined" color="primary" onDelete={onDelete} />
+      <Chip label="deletable chip" variant="default" color="primary" onDelete={onDelete} />
     </div>
     <div style={{ marginRight: "1rem" }}>
       <Chip label="small deletable chip for multiselect" variant="default" color="secondary" size="small" onDelete={onDelete} />
@@ -40,7 +40,7 @@ Use a Deletable chip to allow users to remove an entity, like removing a Tag fro
 ```jsx
 const onDelete = () => { console.log("stuff") };
 <div>
-  <Chip label="stuff.csv" variant="default" color="primary" onDelete={onDelete} />
+  <Chip label="sale-fall2019.csv" variant="default" color="primary" onDelete={onDelete} />
 </div>
 ```
 
@@ -51,7 +51,9 @@ Use a Deletable chip in components like a Select or MultiSelect to allow users t
 ```jsx
 const onDelete = () => { console.log("stuff") };
 <div>
-  <Chip label="stuff.csv" variant="default" color="secondary" size="small" onDelete={onDelete} />
+  <Chip label="sale" variant="default" color="secondary" size="small" onDelete={onDelete} />
+  <Chip label="winter-specials" variant="default" color="secondary" size="small" onDelete={onDelete} />
+  <Chip label="sale-fall2019" variant="default" color="secondary" size="small" onDelete={onDelete} />
 </div>
 ```
 

--- a/package/src/components/Chip/Chip.md
+++ b/package/src/components/Chip/Chip.md
@@ -15,7 +15,10 @@ const onDelete = () => { console.log("stuff") };
 <div>
   <div style={{ display: "flex" }}>
     <div style={{ marginRight: "1rem" }}>
-      <Chip label="stuff.csv" variant="outlined" color="primary" onDelete={onDelete} />
+      <Chip label="deletable chip" variant="outlined" color="primary" onDelete={onDelete} />
+    </div>
+    <div style={{ marginRight: "1rem" }}>
+      <Chip label="small deletable chip for multiselect" variant="default" color="secondary" size="small" onDelete={onDelete} />
     </div>
     <div style={{ marginRight: "1rem" }}>
       <Chip color="error" label="Order Cancelled" />
@@ -32,18 +35,31 @@ const onDelete = () => { console.log("stuff") };
 
 <!-- Explain when to use this type of the component, and give a real life Reaction Admin example -->
 
-Use a Deletable chip to allow a user to remove something, like removing a tag from a filter. To create a Deletable chip, pass a Delete function to `onDelete`.
+Use a Deletable chip to allow users to remove an entity, like removing a Tag from a filter input. To create a Deletable chip, pass a Delete function to `onDelete`, and use the `default` variant with the `primary` color.
 
 ```jsx
 const onDelete = () => { console.log("stuff") };
-<Chip label="stuff.csv" variant="outlined" color="primary" onDelete={onDelete} />
+<div>
+  <Chip label="stuff.csv" variant="default" color="primary" onDelete={onDelete} />
+</div>
+```
+
+##### Deletable chip for Selects, MultiSelects
+
+Use a Deletable chip in components like a Select or MultiSelect to allow users to remove entities within another action. To create a Deletable chip for a Select or MultiSelect, use the `default` variant with the `secondary` color and `small` size props, along with p assing an `onDelete` function.
+
+```jsx
+const onDelete = () => { console.log("stuff") };
+<div>
+  <Chip label="stuff.csv" variant="default" color="secondary" size="small" onDelete={onDelete} />
+</div>
 ```
 
 ##### Error chip
 
 <!-- Explain when to use this type of the component, and give a real life Reaction Admin example -->
 
-The error chip is used to indicate an error status, such as when an order has been cancelled.
+The Error chip is used to indicate an error status, such as when an order has been cancelled.
 
 ```jsx
 <Chip color="error" label="Order Cancelled" />

--- a/package/src/components/Chip/Chip.test.js
+++ b/package/src/components/Chip/Chip.test.js
@@ -7,7 +7,20 @@ test("basic snapshot - only default props", () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
+test("deletable chip snapshot", () => {
+  const onDelete = () => { };
+  const { asFragment } = render(<Chip color="primary" variant="default" onDelete={onDelete} />);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("deletable chip in small, secondary sizesnapshot", () => {
+  const onDelete = () => { };
+  const { asFragment } = render(<Chip color="secondary" variant="default" onDelete={onDelete} size="small" />);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+
 test("error chip snapshot", () => {
-  const { asFragment } = render(<Chip color="error" variant="contained" />);
+  const { asFragment } = render(<Chip color="error"/>);
   expect(asFragment()).toMatchSnapshot();
 });

--- a/package/src/components/Chip/__snapshots__/Chip.test.js.snap
+++ b/package/src/components/Chip/__snapshots__/Chip.test.js.snap
@@ -12,10 +12,60 @@ exports[`basic snapshot - only default props 1`] = `
 </DocumentFragment>
 `;
 
+exports[`deletable chip in small, secondary sizesnapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiChip-root MuiChip-colorSecondary MuiChip-deletableColorSecondary MuiChip-sizeSmall MuiChip-deletable"
+    role="button"
+    tabindex="0"
+  >
+    <span
+      class="MuiChip-label MuiChip-labelSmall"
+    />
+    <svg
+      aria-hidden="true"
+      class="MuiSvgIcon-root MuiChip-deleteIcon MuiChip-deleteIconColorSecondary MuiChip-deleteIconSmall"
+      focusable="false"
+      role="presentation"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+      />
+    </svg>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`deletable chip snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiChip-root MuiChip-colorPrimary MuiChip-deletableColorPrimary MuiChip-deletable"
+    role="button"
+    tabindex="0"
+  >
+    <span
+      class="MuiChip-label"
+    />
+    <svg
+      aria-hidden="true"
+      class="MuiSvgIcon-root MuiChip-deleteIcon MuiChip-deleteIconColorPrimary"
+      focusable="false"
+      role="presentation"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+      />
+    </svg>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`error chip snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="MuiChip-root MuiChip-colorPrimary MuiChip-outlined MuiChip-outlinedPrimary makeStyles-outlinedPrimary-34"
+    class="MuiChip-root MuiChip-colorPrimary MuiChip-outlined MuiChip-outlinedPrimary makeStyles-outlinedPrimary-116"
   >
     <span
       class="MuiChip-label"

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -289,6 +289,11 @@ export const rawMuiTheme = {
         fontSize: defaultFontSize * 0.875,
         letterSpacing: 0.28
       },
+      deletable: {
+        "&:hover": {
+          cursor: "pointer"
+        }
+      },
       deletableColorPrimary: {
         "backgroundColor": colors.black02,
         "border": `1px solid ${colors.black30}`,

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -294,7 +294,7 @@ export const rawMuiTheme = {
         "border": `1px solid ${colors.black30}`,
         "color": colors.coolGrey500,
         "&:hover, &:focus, &:active": {
-          backgroundColor: colors.black02
+          backgroundColor: colors.black05
         }
       },
       deleteIconColorPrimary: {
@@ -309,7 +309,7 @@ export const rawMuiTheme = {
         "border": `1px solid ${colors.coolGrey300}`,
         "backgroundColor": colors.reactionBlue100,
         "&:hover, &:focus, &:active": {
-          backgroundColor: colors.reactionBlue100
+          backgroundColor: colors.darkBlue100
         }
       },
       deleteIconColorSecondary: {

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -284,6 +284,45 @@ export const rawMuiTheme = {
         }
       }
     },
+    MuiChip: {
+      root: {
+        fontSize: defaultFontSize * 0.875,
+        letterSpacing: 0.28
+      },
+      deletable: {
+        backgroundColor: colors.black02,
+        border: `1px solid ${colors.black30}`,
+        color: colors.coolGrey500
+      },
+      deleteIconColorPrimary: {
+        "color": colors.coolGrey,
+        "fontSize": 17,
+        "&:hover": {
+          color: colors.reactionBlue500
+        }
+      },
+      deletableColorSecondary: {
+        "color": colors.coolGrey500,
+        "border": `1px solid ${colors.coolGrey300}`,
+        "backgroundColor": colors.reactionBlue100,
+        "&:hover": {
+          backgroundColor: colors.reactionBlue100
+        }
+      },
+      deleteIconColorSecondary: {
+        "color": colors.coolGrey,
+        "&:hover": {
+          color: colors.reactionBlue500
+        }
+      },
+      sizeSmall: {
+        height: 30
+      },
+      deleteIconSmall: {
+        margin: "0 4px 0 0",
+        fontSize: 17
+      }
+    },
     MuiDialogTitle: {
       root: {
         padding: defaultTheme.spacing(4, 4, 1, 4)

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -289,15 +289,18 @@ export const rawMuiTheme = {
         fontSize: defaultFontSize * 0.875,
         letterSpacing: 0.28
       },
-      deletable: {
-        backgroundColor: colors.black02,
-        border: `1px solid ${colors.black30}`,
-        color: colors.coolGrey500
+      deletableColorPrimary: {
+        "backgroundColor": colors.black02,
+        "border": `1px solid ${colors.black30}`,
+        "color": colors.coolGrey500,
+        "&:hover, &:focus, &:active": {
+          backgroundColor: colors.black02
+        }
       },
       deleteIconColorPrimary: {
         "color": colors.coolGrey,
         "fontSize": 17,
-        "&:hover": {
+        "&:hover, &:focus, &:active": {
           color: colors.reactionBlue500
         }
       },
@@ -305,13 +308,13 @@ export const rawMuiTheme = {
         "color": colors.coolGrey500,
         "border": `1px solid ${colors.coolGrey300}`,
         "backgroundColor": colors.reactionBlue100,
-        "&:hover": {
+        "&:hover, &:focus, &:active": {
           backgroundColor: colors.reactionBlue100
         }
       },
       deleteIconColorSecondary: {
         "color": colors.coolGrey,
-        "&:hover": {
+        "&:hover, &:focus, &:active": {
           color: colors.reactionBlue500
         }
       },

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -25,6 +25,12 @@ export const fontWeightMedium = 500;
 export const fontWeightSemiBold = 600;
 export const fontWeightBold = 700;
 
+// Typography - Letter-spacing
+export const captionLetterSpacing = 0.28;
+
+// Icons
+export const smallFontIconSize = 17;
+
 export const rawMuiTheme = {
   palette: {
     colors, // TODO: De-structure these colors into various MUI properties rather than using them from this object
@@ -107,7 +113,8 @@ export const rawMuiTheme = {
       lineHeight: 1.5
     },
     caption: {
-      color: colors.black30
+      color: colors.black30,
+      letterSpacing: captionLetterSpacing
     },
     subtitle1: {
       fontSize: defaultFontSize * 0.875,
@@ -287,7 +294,7 @@ export const rawMuiTheme = {
     MuiChip: {
       root: {
         fontSize: defaultFontSize * 0.875,
-        letterSpacing: 0.28
+        letterSpacing: captionLetterSpacing
       },
       deletable: {
         "&:hover": {
@@ -304,7 +311,7 @@ export const rawMuiTheme = {
       },
       deleteIconColorPrimary: {
         "color": colors.coolGrey,
-        "fontSize": 17,
+        "fontSize": smallFontIconSize,
         "&:hover, &:focus, &:active": {
           color: colors.reactionBlue500
         }
@@ -328,7 +335,7 @@ export const rawMuiTheme = {
       },
       deleteIconSmall: {
         margin: "0 4px 0 0",
-        fontSize: 17
+        fontSize: smallFontIconSize
       }
     },
     MuiDialogTitle: {


### PR DESCRIPTION
Resolves #52 
Impact: **minor**  
Type: **feature|style|docs**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component: Chip
- Add styles to create a Deletable chip: Use `default` variant with `onDelete()`
- Add styles to create a Deletable chip in small/secondary size and color, for MultiSelect: Use `default` variant with `small` size, `secondary` color and `onDelete()`
- Add test cases for the 2 new types of Chips; update snapshots
- Fix a previous error type Chip test

## Screenshots: Zeplin vs. Docs

How it will be used in Admin:

<img width="1156" alt="Screen Shot 2019-08-14 at 4 08 49 PM" src="https://user-images.githubusercontent.com/3673236/63062507-19ec1500-beae-11e9-8be5-a68f50f51473.png">

How it looks:
<img width="417" alt="Screen Shot 2019-08-14 at 4 13 04 PM" src="https://user-images.githubusercontent.com/3673236/63062609-6afc0900-beae-11e9-9361-d20da1d937ef.png">

## Breaking changes
None

## Testing

### Deletable chip

1. Test regular state
1. Test hover state

### Deletable chip for MultiSelect

1. Test regular state
1. Test hover state
1. Test size is set to small