### PR TITLE
fix: revert hoverOpacity to default theme value

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.5
+version: v1.12.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:hoek:20180212':
@@ -77,5 +77,5 @@ ignore:
   'npm:mem:20180117':
     - libnpx > yargs > os-locale > mem:
         reason: No update available
-        expires: '2019-08-16T03:20:49.029Z'
+        expires: '2019-09-16T00:24:48.037Z'
 patch: {}

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -46,7 +46,6 @@ export const rawMuiTheme = {
     },
     action: {
       hover: colors.reactionBlue100,
-      hoverOpacity: 1,
       selected: colors.black10
     }
   },


### PR DESCRIPTION
Impact: **major**  
Type: **bugfix**

## Component

Buttons, and other actions possibly

## Screenshots

![image](https://user-images.githubusercontent.com/42217/63203215-f6a69e80-c042-11e9-9fbe-b79d32aa9eb9.png)


## Breaking changes

none.

## Testing
1. Hover over the text button.
2. See the BG is not black, but a softer grey
