### PR TITLE
fix(button): set line-height to 1.5, resulting in 40px high buttons

### DIFF
--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -226,7 +226,7 @@ export const rawMuiTheme = {
     },
     MuiButton: {
       root: {
-        lineHeight: "1.5",
+        lineHeight: 1.5,
         padding: `${defaultSpacingUnit}px ${defaultSpacingUnit * 2}px`,
         textTransform: "initial"
       },

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -226,6 +226,7 @@ export const rawMuiTheme = {
     },
     MuiButton: {
       root: {
+        lineHeight: "1.5",
         padding: `${defaultSpacingUnit}px ${defaultSpacingUnit * 2}px`,
         textTransform: "initial"
       },


### PR DESCRIPTION
Resolves #67 
Impact: **minor**  
Type: **bugfix|style**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component: Button
- Change the `defaultTheme`'s `MuiButton`'s `root` style to use `1.5`, not `1.75` as line-height. This results in the overall button being 40px high for regular, and 29px/30px high for `small` height buttons. Currently, the buttons are coming out to 44px high.
- Docs: Show an example of a ButtonGroup with a Text Only next to a Contained button

## Screenshots
<img width="1048" alt="Screen Shot 2019-08-19 at 2 59 38 PM" src="https://user-images.githubusercontent.com/3673236/63302480-04059800-c292-11e9-8573-174b6a88add5.png">
<img width="441" alt="Screen Shot 2019-08-19 at 2 59 48 PM" src="https://user-images.githubusercontent.com/3673236/63302481-04059800-c292-11e9-97a6-f8af16c4f6c3.png">
<img width="625" alt="Screen Shot 2019-08-19 at 3 00 24 PM" src="https://user-images.githubusercontent.com/3673236/63302510-18499500-c292-11e9-9a5c-df8918dcb37d.png">

## Breaking changes
None

## Testing
1. Test Button in short and default, in contained and outlined
1. Test SplitButton
1. Test the ConfirmDialog, which has a Button in it
