### PR TITLE
fix(select): update style for select

### DIFF
--- a/package/src/components/Select/Select.js
+++ b/package/src/components/Select/Select.js
@@ -49,7 +49,7 @@ const useStyles = makeStyles((theme) => ({
   noOptionsMessage: {
     padding: theme.spacing(1, 2),
     color: theme.palette.colors.black20,
-    minHeight: theme.spacing(5)
+    lineHeight: "40px"
   },
   placeholder: {
     position: "absolute",
@@ -59,20 +59,23 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.colors.black55
   },
   paper: {
-    position: "absolute",
-    zIndex: 1,
-    marginTop: 0,
-    left: 0,
-    right: 0,
-    borderTop: 0
+    "position": "absolute",
+    "zIndex": 1,
+    "marginTop": 0,
+    "left": 0,
+    "right": 0,
+    "borderTop": 0,
+    "minHeight": theme.spacing(5),
+    "& div": {
+      paddingTop: 0,
+      paddingBottom: 0
+    }
   },
   divider: {
     height: theme.spacing(2),
     color: theme.palette.colors.black20
   }
 }));
-
-// const IndicatorSeparator = ({ innerProps }) => <span style={indicatorSeparatorStyle} {...innerProps} />;
 
 // Custom components for various aspects of the select
 const components = {

--- a/package/src/components/Select/Select.js
+++ b/package/src/components/Select/Select.js
@@ -23,7 +23,8 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(0.25),
     height: "auto",
     cursor: "pointer",
-    fontSize: theme.typography.fontSize,
+    fontSize: theme.typography.caption.fontSize,
+    letterSpacing: theme.typography.caption.letterSpacing,
     background: theme.palette.colors.black02,
     border: `1px solid ${theme.palette.colors.black20}`,
     borderRadius: theme.shape.borderRadius
@@ -47,6 +48,7 @@ const useStyles = makeStyles((theme) => ({
     position: "absolute",
     left: theme.spacing(1),
     fontSize: theme.typography.caption.fontSize,
+    letterSpacing: theme.typography.caption.letterSpacing,
     color: theme.palette.colors.black20
   },
   paper: {

--- a/package/src/components/Select/Select.js
+++ b/package/src/components/Select/Select.js
@@ -19,6 +19,7 @@ const useStyles = makeStyles((theme) => ({
     minWidth: 290
   },
   input: {
+    color: theme.palette.colors.coolGrey500,
     display: "flex",
     padding: theme.spacing(0.25),
     height: "auto",
@@ -26,7 +27,6 @@ const useStyles = makeStyles((theme) => ({
     fontSize: theme.typography.caption.fontSize,
     letterSpacing: theme.typography.caption.letterSpacing,
     background: theme.palette.colors.black02,
-    border: `1px solid ${theme.palette.colors.black20}`,
     borderRadius: theme.shape.borderRadius
   },
   valueContainer: {
@@ -39,6 +39,11 @@ const useStyles = makeStyles((theme) => ({
   },
   chip: {
     margin: theme.spacing(0.5, 0.25)
+  },
+  menuItem: {
+    paddingTop: 0,
+    paddingBottom: 0,
+    minHeight: theme.spacing(5)
   },
   noOptionsMessage: {
     padding: theme.spacing(1, 2),
@@ -54,12 +59,13 @@ const useStyles = makeStyles((theme) => ({
   paper: {
     position: "absolute",
     zIndex: 1,
-    marginTop: theme.spacing(1),
+    marginTop: 0,
     left: 0,
     right: 0
   },
   divider: {
-    height: theme.spacing(2)
+    height: theme.spacing(2),
+    color: theme.palette.colors.black20
   }
 }));
 
@@ -101,7 +107,6 @@ const Select = React.forwardRef(function Select(props, ref) {
   const selectStyles = {
     input: (base) => ({
       ...base,
-      "color": theme.palette.text.primary,
       "& input": {
         font: "inherit"
       }
@@ -125,6 +130,14 @@ const Select = React.forwardRef(function Select(props, ref) {
           }
         }}
         value={value}
+        theme={(selectTheme) => ({
+          ...selectTheme,
+          borderRadius: 0,
+          colors: {
+            ...theme.colors,
+            neutral20: theme.palette.colors.coolGrey500
+          }
+        })}
         {...otherProps}
       />
     </div>

--- a/package/src/components/Select/Select.js
+++ b/package/src/components/Select/Select.js
@@ -5,6 +5,7 @@ import AsyncSelect from "react-select/async";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
 import {
   Control,
+  IndicatorSeparator,
   Menu,
   MultiValue,
   NoOptionsMessage,
@@ -71,9 +72,12 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
+// const IndicatorSeparator = ({ innerProps }) => <span style={indicatorSeparatorStyle} {...innerProps} />;
+
 // Custom components for various aspects of the select
 const components = {
   Control,
+  IndicatorSeparator,
   Menu,
   MultiValue,
   NoOptionsMessage,

--- a/package/src/components/Select/Select.js
+++ b/package/src/components/Select/Select.js
@@ -118,7 +118,6 @@ const Select = React.forwardRef(function Select(props, ref) {
         inputId="react-select-multiple"
         onChange={handleChangeMulti}
         ref={ref}
-        // styles={selectStyles}
         innerRef={ref}
         TextFieldProps={{
           InputLabelProps: {

--- a/package/src/components/Select/Select.js
+++ b/package/src/components/Select/Select.js
@@ -61,7 +61,12 @@ const useStyles = makeStyles((theme) => ({
     zIndex: 1,
     marginTop: 0,
     left: 0,
-    right: 0
+    right: 0,
+    borderTop: 0,
+    div: {
+      paddingTop: 0,
+      paddingBottom: 0
+    }
   },
   divider: {
     height: theme.spacing(2),

--- a/package/src/components/Select/Select.js
+++ b/package/src/components/Select/Select.js
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme) => ({
   placeholder: {
     position: "absolute",
     left: theme.spacing(1),
-    fontSize: theme.typography.fontSize,
+    fontSize: theme.typography.caption.fontSize,
     color: theme.palette.colors.black20
   },
   paper: {

--- a/package/src/components/Select/Select.js
+++ b/package/src/components/Select/Select.js
@@ -54,7 +54,7 @@ const useStyles = makeStyles((theme) => ({
     left: theme.spacing(1),
     fontSize: theme.typography.caption.fontSize,
     letterSpacing: theme.typography.caption.letterSpacing,
-    color: theme.palette.colors.black20
+    color: theme.palette.colors.black55
   },
   paper: {
     position: "absolute",
@@ -62,11 +62,7 @@ const useStyles = makeStyles((theme) => ({
     marginTop: 0,
     left: 0,
     right: 0,
-    borderTop: 0,
-    div: {
-      paddingTop: 0,
-      paddingBottom: 0
-    }
+    borderTop: 0
   },
   divider: {
     height: theme.spacing(2),

--- a/package/src/components/Select/Select.js
+++ b/package/src/components/Select/Select.js
@@ -105,15 +105,6 @@ const Select = React.forwardRef(function Select(props, ref) {
     onSelection && onSelection(selectedValue);
   }
 
-  const selectStyles = {
-    input: (base) => ({
-      ...base,
-      "& input": {
-        font: "inherit"
-      }
-    })
-  };
-
   return (
     <div className={defaultClasses.root}>
       <SelectComponent
@@ -122,7 +113,7 @@ const Select = React.forwardRef(function Select(props, ref) {
         inputId="react-select-multiple"
         onChange={handleChangeMulti}
         ref={ref}
-        styles={selectStyles}
+        // styles={selectStyles}
         innerRef={ref}
         TextFieldProps={{
           InputLabelProps: {
@@ -136,7 +127,7 @@ const Select = React.forwardRef(function Select(props, ref) {
           borderRadius: 0,
           colors: {
             ...theme.colors,
-            neutral20: theme.palette.colors.coolGrey500
+            neutral20: "#3c3c3c"
           }
         })}
         {...otherProps}

--- a/package/src/components/Select/Select.js
+++ b/package/src/components/Select/Select.js
@@ -47,7 +47,8 @@ const useStyles = makeStyles((theme) => ({
   },
   noOptionsMessage: {
     padding: theme.spacing(1, 2),
-    color: theme.palette.colors.black20
+    color: theme.palette.colors.black20,
+    minHeight: theme.spacing(5)
   },
   placeholder: {
     position: "absolute",

--- a/package/src/components/Select/Select.md
+++ b/package/src/components/Select/Select.md
@@ -101,7 +101,7 @@ function handleOnSelection(value) {
 ```
 #### Async options
 
-Multi value select with options provided asynchronously:
+MultiSelect with options provided asynchronously:
 
 ```jsx
 import options from "./helpers/tagData";

--- a/package/src/components/Select/Select.md
+++ b/package/src/components/Select/Select.md
@@ -1,12 +1,13 @@
 ### Overview
 The `Select` component provides functionality to select single or multiple value(s) with
-autocompletion; options may be provided synchronously or asynchronously. Under the hood, the [react-select](https://react-select.com) component is used.
+autocompletion; options may be provided synchronously or asynchronously. 
 
-**NOTE**: In addition to the props listed above, all props supported by `react-select` will be passed through. To see the full list click [here](https://react-select.com/props)
+Under the hood, the [react-select](https://react-select.com) component is used. In addition to the props listed above, all props supported by `react-select` will be passed through. To see the full list click [here](https://react-select.com/props).
 
 ### Usage
 
-#### Basic Single Select
+#### Single select
+
 Single value select with options provided synchronously:
 ```jsx
 const options = [
@@ -27,8 +28,32 @@ function handleOnSelection(value) {
   />
 ```
 
-#### Basic Multi Select
-Multi value select with options provided synchronously:
+When the select is open:
+
+```jsx
+const options = [
+  { value: "adult", label: "Adults" },
+  { value: "kids", label: "Kids" }
+];
+
+// Log selected value
+function handleOnSelection(value) {
+  console.log("Selected value: ", value);
+}
+
+<div style={{marginBottom: "90px"}}>
+  <Select 
+    onSelection={handleOnSelection}
+    options={options}
+    placeholder="Select a tag"
+    menuIsOpen
+    />
+</div>
+```
+
+#### MultiSelect
+
+MultiSelect with options provided synchronously:
 ```jsx
 const options = [
   { value: "mens", label: "Mens" },
@@ -49,8 +74,35 @@ function handleOnSelection(value) {
   />
 ```
 
+When the select is opened and there are no other values left:
+
+```jsx
+const options = [
+  { value: "mens", label: "Mens" },
+  { value: "womens", label: "Womens" },
+  { value: "kids", label: "Kids" }
+];
+
+// Log selected value
+function handleOnSelection(value) {
+  console.log("Selected value: ", value);
+}
+
+<div style={{marginBottom: "50px"}}>
+  <Select
+    isMulti
+    onSelection={handleOnSelection}
+    options={options}
+    placeholder="Select tags"
+    value={options}
+    menuIsOpen
+    />
+</div>
+```
 #### Async options
+
 Multi value select with options provided asynchronously:
+
 ```jsx
 import options from "./helpers/tagData";
 

--- a/package/src/components/Select/__snapshots__/Select.test.js.snap
+++ b/package/src/components/Select/__snapshots__/Select.test.js.snap
@@ -23,12 +23,12 @@ exports[`basic snapshot test 1`] = `
               class="makeStyles-valueContainer-3"
             >
               <p
-                class="MuiTypography-root makeStyles-placeholder-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+                class="MuiTypography-root makeStyles-placeholder-7 MuiTypography-body1 MuiTypography-colorTextSecondary"
               >
                 Select options
               </p>
               <div
-                class="css-1tna5xz"
+                class="css-yi4co9"
               >
                 <div
                   class=""
@@ -56,11 +56,11 @@ exports[`basic snapshot test 1`] = `
               class=" css-1wy0on6"
             >
               <span
-                class=" css-1okebmr-indicatorSeparator"
+                class=" css-14ctuyv-indicatorSeparator"
               />
               <div
                 aria-hidden="true"
-                class=" css-tlfecz-indicatorContainer"
+                class=" css-1dk35j4-indicatorContainer"
               >
                 <svg
                   aria-hidden="true"
@@ -79,11 +79,11 @@ exports[`basic snapshot test 1`] = `
           </div>
           <fieldset
             aria-hidden="true"
-            class="PrivateNotchedOutline-root-77 MuiOutlinedInput-notchedOutline"
+            class="PrivateNotchedOutline-root-78 MuiOutlinedInput-notchedOutline"
             style="padding-left: 8px;"
           >
             <legend
-              class="PrivateNotchedOutline-legend-78"
+              class="PrivateNotchedOutline-legend-79"
               style="width: 0px;"
             >
               <span>

--- a/package/src/components/Select/__snapshots__/Select.test.js.snap
+++ b/package/src/components/Select/__snapshots__/Select.test.js.snap
@@ -28,7 +28,7 @@ exports[`basic snapshot test 1`] = `
                 Select options
               </p>
               <div
-                class="css-yi4co9"
+                class="css-3y1qaa"
               >
                 <div
                   class=""
@@ -47,7 +47,7 @@ exports[`basic snapshot test 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -56,7 +56,10 @@ exports[`basic snapshot test 1`] = `
               class=" css-1wy0on6"
             >
               <span
-                class=" css-14ctuyv-indicatorSeparator"
+                options="[object Object],[object Object],[object Object]"
+                selectprops="[object Object]"
+                style="align-self: stretch; background-color: rgb(204, 204, 204); margin-bottom: 8px; margin-top: 8px; width: 1px;"
+                theme="[object Object]"
               />
               <div
                 aria-hidden="true"

--- a/package/src/components/Select/helpers/IndicatorSeparator.js
+++ b/package/src/components/Select/helpers/IndicatorSeparator.js
@@ -1,0 +1,26 @@
+import React from "react";
+import PropTypes from "prop-types";
+import defaultTheme from "../../../theme/defaultTheme";
+
+/**
+ * @name IndicatorSeparator
+ * @param {Object} props Component props
+ * @returns {React.Component} A React component
+ */
+export default function IndicatorSeparator(props) {
+  const indicatorSeparatorStyle = {
+    alignSelf: "stretch",
+    backgroundColor: defaultTheme.palette.colors.black20,
+    marginBottom: 8,
+    marginTop: 8,
+    width: 1
+  };
+
+  return (
+    <span style={indicatorSeparatorStyle} {...props} />
+  );
+}
+
+IndicatorSeparator.propTypes = {
+  props: PropTypes.object.isRequired
+};

--- a/package/src/components/Select/helpers/Menu.js
+++ b/package/src/components/Select/helpers/Menu.js
@@ -10,7 +10,7 @@ import { Paper } from "@material-ui/core";
 export default function Menu(props) {
   return (
     <Paper
-      rounded
+      rounded="true"
       elevation={2}
       className={props.selectProps.classes.paper}
       {...props.innerProps}

--- a/package/src/components/Select/helpers/Menu.js
+++ b/package/src/components/Select/helpers/Menu.js
@@ -10,7 +10,6 @@ import { Paper } from "@material-ui/core";
 export default function Menu(props) {
   return (
     <Paper
-      rounded="true"
       elevation={2}
       className={props.selectProps.classes.paper}
       {...props.innerProps}

--- a/package/src/components/Select/helpers/NoOptionsMessage.js
+++ b/package/src/components/Select/helpers/NoOptionsMessage.js
@@ -10,7 +10,7 @@ import { Typography } from "@material-ui/core";
 export default function NoOptionsMessage(props) {
   return (
     <Typography
-      color="textSecondary"
+      variant="caption"
       className={props.selectProps.classes.noOptionsMessage}
       {...props.innerProps}
     >

--- a/package/src/components/Select/helpers/Option.js
+++ b/package/src/components/Select/helpers/Option.js
@@ -12,6 +12,7 @@ export default function Option(props) {
     <MenuItem
       ref={props.innerRef}
       component="div"
+      className={props.selectProps.classes.menuItem}
       selected={props.isFocused}
       {...props.innerProps}
     >
@@ -25,6 +26,10 @@ Option.propTypes = {
    * The children to be rendered.
    */
   children: PropTypes.node,
+  /**
+   * CSS class passed down from parent
+   */
+  className: PropTypes.string,
   /**
    * props passed to the wrapping element for the group.
    */

--- a/package/src/components/Select/helpers/Option.js
+++ b/package/src/components/Select/helpers/Option.js
@@ -58,5 +58,6 @@ Option.propTypes = {
   /**
    * Whether the option is selected.
    */
-  isSelected: PropTypes.bool.isRequired
+  isSelected: PropTypes.bool.isRequired,
+  selectProps: PropTypes.object.isRequired
 };

--- a/package/src/components/Select/helpers/index.js
+++ b/package/src/components/Select/helpers/index.js
@@ -1,4 +1,5 @@
 import Control from "./Control";
+import IndicatorSeparator from "./IndicatorSeparator";
 import Menu from "./Menu";
 import MultiValue from "./MultiValue";
 import NoOptionsMessage from "./NoOptionsMessage";
@@ -8,6 +9,7 @@ import ValueContainer from "./ValueContainer";
 
 export {
   Control,
+  IndicatorSeparator,
   Menu,
   MultiValue,
   NoOptionsMessage,

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -383,6 +383,14 @@ export const rawMuiTheme = {
       }
     },
     MuiOutlinedInput: {
+      root: {
+        "&:hover $notchedOutline": {
+          borderColor: colors.black20
+        },
+        "&$focused $notchedOutline": {
+          borderColor: colors.teal500
+        }
+      },
       inputMarginDense: {
         paddingTop: 8,
         paddingBottom: 8

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -418,7 +418,7 @@ export const rawMuiTheme = {
           borderColor: colors.black20
         },
         "&$focused $notchedOutline": {
-          borderColor: colors.teal500
+          borderColor: colors.blue400
         }
       },
       inputMarginDense: {

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -114,6 +114,7 @@ export const rawMuiTheme = {
     },
     caption: {
       color: colors.black30,
+      fontSize: defaultFontSize * 0.875,
       letterSpacing: captionLetterSpacing
     },
     subtitle1: {

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -418,7 +418,7 @@ export const rawMuiTheme = {
           borderColor: colors.black20
         },
         "&$focused $notchedOutline": {
-          borderColor: colors.blue400
+          borderColor: colors.reactionBlue400
         }
       },
       inputMarginDense: {

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -132,16 +132,10 @@ export const rawMuiTheme = {
       lineHeight: 1.25
     },
     caption: {
-<<<<<<< HEAD
-      color: colors.black30,
-      fontSize: defaultFontSize * 0.875,
-      letterSpacing: captionLetterSpacing
-=======
       color: colors.coolGrey500,
       fontSize: defaultFontSize * 0.875,
       letterSpacing: captionLetterSpacing,
       lineHeight: 1.25
->>>>>>> master
     },
     subtitle1: {
       color: colors.coolGrey500,


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Resolves #71 
Impact: **minor**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Select
- Placeholder text should be 14px, not 16px for both the single and multi Select
- A lot of style/design changes.

## Screenshots
<img width="1440" alt="Screen Shot 2019-08-21 at 6 51 56 PM" src="https://user-images.githubusercontent.com/3673236/63479894-c9902c80-c444-11e9-89f8-f846e3b1a723.png">

<img width="577" alt="Screen Shot 2019-08-28 at 4 49 48 PM" src="https://user-images.githubusercontent.com/3673236/63900808-b33f1f00-c9b6-11e9-8788-752019dafb94.png">
<img width="591" alt="Screen Shot 2019-08-28 at 4 49 51 PM" src="https://user-images.githubusercontent.com/3673236/63900810-b33f1f00-c9b6-11e9-80c4-0f5878a0784d.png">

## Breaking changes
This component requires the latest version of `react-select`. Using this component in an app with older versions of `react-select` will have to be updated.

## Testing
1. Design review
1. Code review