### PR TITLE
feat: add ActionMenu component

### DIFF
--- a/package/src/components/ActionMenu/ActionMenu.js
+++ b/package/src/components/ActionMenu/ActionMenu.js
@@ -2,11 +2,9 @@ import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import {
   Box,
-  ClickAwayListener,
   ListItemText,
   Menu,
   MenuItem,
-  MenuList,
   makeStyles
 } from "@material-ui/core";
 import ChevronDownIcon from "mdi-material-ui/ChevronDown";
@@ -70,6 +68,8 @@ const ActionMenu = React.forwardRef(function ActionMenu(props, ref) {
   return (
     <Fragment>
       <Button
+        aria-controls="action-menu"
+        aria-haspopup="true"
         className={classes.button}
         onClick={handleToggle}
         ref={anchorRef}
@@ -80,32 +80,35 @@ const ActionMenu = React.forwardRef(function ActionMenu(props, ref) {
           <ChevronDownIcon />
         </Box>
       </Button>
-      <Menu open={open} anchorEl={anchorRef.current}>
-        <ClickAwayListener onClickAway={handleClose}>
-          <MenuList disablePadding>
-            <MenuItem key="default-label" disabled>
-              <Box maxWidth={320} whiteSpace="normal">
-                <ListItemText
-                  primary={children}
-                />
-              </Box>
-            </MenuItem>
-            {options.map(({ label, details, isDisabled }, index) => (
-              <MenuItem
-                key={index}
-                disabled={isDisabled}
-                onClick={(event) => handleMenuItemClick(event, index)}
-              >
-                <Box maxWidth={320} whiteSpace="normal">
-                  <ListItemText
-                    primary={label}
-                    secondary={details}
-                  />
-                </Box>
-              </MenuItem>
-            ))}
-          </MenuList>
-        </ClickAwayListener>
+      <Menu
+        MenuListProps={{ disablePadding: true }}
+        anchorEl={anchorRef.current}
+        id="action-menu"
+        keepMounted
+        open={open}
+        onClose={handleClose}
+      >
+        <MenuItem key="default-label" disabled>
+          <Box maxWidth={320} whiteSpace="normal">
+            <ListItemText
+              primary={children}
+            />
+          </Box>
+        </MenuItem>
+        {options.map(({ label, details, isDisabled }, index) => (
+          <MenuItem
+            key={index}
+            disabled={isDisabled}
+            onClick={(event) => handleMenuItemClick(event, index)}
+          >
+            <Box maxWidth={320} whiteSpace="normal">
+              <ListItemText
+                primary={label}
+                secondary={details}
+              />
+            </Box>
+          </MenuItem>
+        ))}
       </Menu>
     </Fragment>
   );

--- a/package/src/components/ActionMenu/ActionMenu.js
+++ b/package/src/components/ActionMenu/ActionMenu.js
@@ -1,0 +1,154 @@
+import React, { Fragment } from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  ClickAwayListener,
+  ListItemText,
+  Menu,
+  MenuItem,
+  MenuList,
+  makeStyles
+} from "@material-ui/core";
+import ChevronDownIcon from "mdi-material-ui/ChevronDown";
+import Button from "../Button";
+
+const useStyles = makeStyles((theme) => ({
+  button: {
+    paddingRight: theme.spacing(1.5)
+  }
+}));
+
+/**
+ * @name ActionMenu
+ * @param {Object} props Component props
+ * @returns {React.Component} A React component
+ */
+const ActionMenu = React.forwardRef(function ActionMenu(props, ref) {
+  const {
+    children,
+    onSelect,
+    options,
+    ...otherProps
+  } = props;
+  const classes = useStyles();
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = ref || React.useRef(null);
+
+  /**
+   * Handle menu item click
+   * @param {SyntheticEvent} event Event object
+   * @param {Number} index Menu item index
+   * @returns {undefined}
+   */
+  function handleMenuItemClick(event, index) {
+    const selectedOption = options[index];
+    onSelect && onSelect(selectedOption, index);
+    setOpen(false);
+  }
+
+  /**
+   * Toggle menu open
+   * @returns {undefined}
+   */
+  function handleToggle() {
+    setOpen((prevOpen) => !prevOpen);
+  }
+
+  /**
+   * Handle menu close
+   * @param {SyntheticEvent} event Event object
+   * @returns {undefined}
+   */
+  function handleClose(event) {
+    if (anchorRef.current && anchorRef.current.contains(event.target)) {
+      return;
+    }
+
+    setOpen(false);
+  }
+
+  return (
+    <Fragment>
+      <Button
+        className={classes.button}
+        onClick={handleToggle}
+        ref={anchorRef}
+        {...otherProps}
+      >
+        {children}
+        <Box display="flex" paddingLeft={1}>
+          <ChevronDownIcon />
+        </Box>
+      </Button>
+      <Menu open={open} anchorEl={anchorRef.current}>
+        <ClickAwayListener onClickAway={handleClose}>
+          <MenuList disablePadding>
+            <MenuItem key="default-label" disabled>
+              <Box maxWidth={320} whiteSpace="normal">
+                <ListItemText
+                  primary={children}
+                />
+              </Box>
+            </MenuItem>
+            {options.map(({ label, details, isDisabled }, index) => (
+              <MenuItem
+                key={index}
+                disabled={isDisabled}
+                onClick={(event) => handleMenuItemClick(event, index)}
+              >
+                <Box maxWidth={320} whiteSpace="normal">
+                  <ListItemText
+                    primary={label}
+                    secondary={details}
+                  />
+                </Box>
+              </MenuItem>
+            ))}
+          </MenuList>
+        </ClickAwayListener>
+      </Menu>
+    </Fragment>
+  );
+});
+
+ActionMenu.defaultProps = {
+  color: "primary",
+  variant: "outlined"
+};
+
+ActionMenu.propTypes = {
+  /**
+   * The content of the Button
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * Options: `default` | `inherit` | `primary` | `secondary` | `error`
+   */
+  color: PropTypes.string,
+  /**
+   * If `true`, the button will be disabled.
+   */
+  disabled: PropTypes.bool, // eslint-disable-line
+  /**
+   * If `true`, the CircularProgress will be displayed and the button will be disabled.
+   */
+  isWaiting: PropTypes.bool,
+  /**
+   * onSelect callback when an option is selected from the menu
+   */
+  onSelect: PropTypes.func,
+  /**
+   * Menu options
+   */
+  options: PropTypes.arrayOf(PropTypes.shape({
+    details: PropTypes.string,
+    isDisabled: PropTypes.bool,
+    label: PropTypes.string.isRequired
+  }))
+};
+
+export default ActionMenu;

--- a/package/src/components/ActionMenu/ActionMenu.md
+++ b/package/src/components/ActionMenu/ActionMenu.md
@@ -10,34 +10,17 @@ This is basic example of how to implement the ActionMenu.
 
 ```jsx
 const options = [{
-  label: "Add tags to products"
+  label: "Filter by file"
 }, {
-  label: "Remove tags from products"
+  label: "Publish"
 }, {
-  label: "Remove all tags from products",
-  isDisabled: true
-}];
-
-<ActionMenu
-  options={options}
-  onSelect={(option, index) => alert(`Selected option "${option.label}" at index (${index})`)}
->
-  Actions
-</ActionMenu>
-```
-
-#### Set the default selected option
-
-Set the default selected option by index.
-
-```jsx
-const options = [{
-  label: "Add tags to products"
+  label: "Make Visible"
 }, {
-  label: "Remove tags from products"
+  label: "Make Hidden"
 }, {
-  label: "Remove all tags from products",
-  isDisabled: true
+  label: "Duplicate"
+}, {
+  label: "Archive"
 }];
 
 <ActionMenu

--- a/package/src/components/ActionMenu/ActionMenu.md
+++ b/package/src/components/ActionMenu/ActionMenu.md
@@ -1,0 +1,155 @@
+### Overview
+
+The Catalyst ActionMenu is based on the the Material-UI example for [Menus](https://material-ui.com/components/menus/). It uses the Catalyst [Button](https://catalyst.reactioncommerce.com/#/Components/Actions/Button) and the Material-UI [Menu](https://material-ui.com/api/menu/) components.
+
+### Usage
+
+#### Simple ActionMenu
+
+This is basic example of how to implement the ActionMenu.
+
+```jsx
+const options = [{
+  label: "Add tags to products"
+}, {
+  label: "Remove tags from products",
+  isDestructive: true
+}, {
+  label: "Remove all tags from products",
+  isDisabled: true,
+  isDestructive: true
+}];
+
+<ActionMenu
+  options={options}
+  onSelect={(option, index) => alert(`Selected option "${option.label}" at index (${index})`)}
+>
+  Actions
+</ActionMenu>
+```
+
+#### Set the default selected option
+
+Set the default selected option by index.
+
+```jsx
+const options = [{
+  label: "Add tags to products"
+}, {
+  label: "Remove tags from products"
+}, {
+  label: "Remove all tags from products",
+  isDisabled: true
+}];
+
+<ActionMenu
+  options={options}
+  onSelect={(option, index) => alert(`Selected option "${option.label}" at index (${index})`)}
+>
+  Actions
+</ActionMenu>
+```
+
+#### Add detail text to options
+
+Add a second line of text to the menu options to provide additional context to an action.
+
+```jsx
+const options = [{
+  label: "Add tags to products",
+  details: "Add the selected tags from the filtered products list provided."
+}, {
+  label: "Remove tags from products",
+  details: "Remove the selected tags from the filtered products list provided."
+}, {
+  label: "Remove all tags from products",
+  details: "Remove all tags from the filtered products list provided.",
+  isDisabled: true
+}];
+
+<ActionMenu
+  options={options}
+  onSelect={(option, index) => alert(`Selected option "${option.label}" at index (${index})`)}
+>
+  Actions
+</ActionMenu>
+```
+
+#### Other variations
+
+```jsx
+import { Grid } from "@material-ui/core";
+
+const options = [{
+  label: "Add tags to products",
+  details: "Add the selected tags from the filtered products list provided."
+}, {
+  label: "Remove tags from products",
+  details: "Remove the selected tags from the filtered products list provided."
+}, {
+  label: "Remove all tags from products",
+  details: "Remove all tags from the filtered products list provided.",
+  isDisabled: true
+}];
+
+const onSelect = (option, index) => alert(`Selected option "${option.label}" at index (${index})`);
+
+<Grid container spacing={2}>
+  <Grid item>
+    <ActionMenu
+      options={options}
+      variant="contained"
+      onSelect={onSelect}
+    >
+      Actions
+    </ActionMenu>
+  </Grid>
+  <Grid item>
+    <ActionMenu
+      options={options}
+      color="secondary"
+      variant="contained"
+      onSelect={onSelect}
+    >
+      Actions
+    </ActionMenu>
+  </Grid>
+  <Grid item>
+    <ActionMenu
+      options={options}
+      color="error"
+      variant="contained"
+      onSelect={onSelect}
+    >
+      Actions
+    </ActionMenu>
+  </Grid>
+  <Grid item>
+    <ActionMenu
+      options={options}
+      color="secondary"
+      onSelect={onSelect}
+    >
+      Actions
+    </ActionMenu>
+  </Grid>
+  <Grid item>
+    <ActionMenu
+      options={options}
+      color="error"
+      onSelect={onSelect}
+    >
+      Actions
+    </ActionMenu>
+  </Grid>
+  <Grid item>
+    <ActionMenu
+      options={options}
+      variant="text"
+      onSelect={onSelect}
+    >
+      Actions
+    </ActionMenu>
+  </Grid>
+</Grid>
+```

--- a/package/src/components/ActionMenu/ActionMenu.md
+++ b/package/src/components/ActionMenu/ActionMenu.md
@@ -12,12 +12,10 @@ This is basic example of how to implement the ActionMenu.
 const options = [{
   label: "Add tags to products"
 }, {
-  label: "Remove tags from products",
-  isDestructive: true
+  label: "Remove tags from products"
 }, {
   label: "Remove all tags from products",
-  isDisabled: true,
-  isDestructive: true
+  isDisabled: true
 }];
 
 <ActionMenu

--- a/package/src/components/ActionMenu/ActionMenu.test.js
+++ b/package/src/components/ActionMenu/ActionMenu.test.js
@@ -20,8 +20,8 @@ test("basic snapshot - only default props", () => {
 
 test("select an option", async () => {
   const onSelect = jest.fn();
-  const { asFragment, getByText } = render(<ActionMenu onSelect={onSelect} options={options}>Actions</ActionMenu>);
-  fireEvent.click(getByText("Actions"));
+  const { asFragment, getAllByText, getByText } = render(<ActionMenu onSelect={onSelect} options={options}>Actions</ActionMenu>);
+  fireEvent.click(getAllByText("Actions")[0]);
   const removeButton = await waitForElement(() => getByText("Remove tags from products"));
   fireEvent.click(removeButton);
   expect(onSelect).toHaveBeenCalled();

--- a/package/src/components/ActionMenu/ActionMenu.test.js
+++ b/package/src/components/ActionMenu/ActionMenu.test.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { fireEvent, render, waitForElement } from "../../tests/index.js";
+import ActionMenu from "./ActionMenu";
+
+const options = [{
+  label: "Add tags to products"
+}, {
+  label: "Remove tags from products",
+  isDestructive: true
+}, {
+  label: "Remove all tags",
+  isDisabled: true,
+  isDestructive: true
+}];
+
+test("basic snapshot - only default props", () => {
+  const { asFragment } = render(<ActionMenu options={options}>Actions</ActionMenu>);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("select an option", async () => {
+  const onSelect = jest.fn();
+  const { asFragment, getByText } = render(<ActionMenu onSelect={onSelect} options={options}>Actions</ActionMenu>);
+  fireEvent.click(getByText("Actions"));
+  const removeButton = await waitForElement(() => getByText("Remove tags from products"));
+  fireEvent.click(removeButton);
+  expect(onSelect).toHaveBeenCalled();
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/package/src/components/ActionMenu/ActionMenu.test.js
+++ b/package/src/components/ActionMenu/ActionMenu.test.js
@@ -5,12 +5,10 @@ import ActionMenu from "./ActionMenu";
 const options = [{
   label: "Add tags to products"
 }, {
-  label: "Remove tags from products",
-  isDestructive: true
+  label: "Remove tags from products"
 }, {
   label: "Remove all tags",
-  isDisabled: true,
-  isDestructive: true
+  isDisabled: true
 }];
 
 test("basic snapshot - only default props", () => {

--- a/package/src/components/ActionMenu/__snapshots__/ActionMenu.test.js.snap
+++ b/package/src/components/ActionMenu/__snapshots__/ActionMenu.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot - only default props 1`] = `
+<DocumentFragment>
+  <button
+    class="MuiButtonBase-root MuiButton-root makeStyles-button-1 MuiButton-outlined MuiButton-outlinedPrimary"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      Actions
+      <div
+        class="MuiBox-root MuiBox-root-26"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+          />
+        </svg>
+      </div>
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</DocumentFragment>
+`;
+
+exports[`select an option 1`] = `
+<DocumentFragment>
+  <button
+    class="MuiButtonBase-root MuiButton-root makeStyles-button-49 MuiButton-outlined MuiButton-outlinedPrimary"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      Actions
+      <div
+        class="MuiBox-root MuiBox-root-74"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+          />
+        </svg>
+      </div>
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</DocumentFragment>
+`;

--- a/package/src/components/ActionMenu/__snapshots__/ActionMenu.test.js.snap
+++ b/package/src/components/ActionMenu/__snapshots__/ActionMenu.test.js.snap
@@ -3,6 +3,8 @@
 exports[`basic snapshot - only default props 1`] = `
 <DocumentFragment>
   <button
+    aria-controls="action-menu"
+    aria-haspopup="true"
     class="MuiButtonBase-root MuiButton-root makeStyles-button-1 MuiButton-outlined MuiButton-outlinedPrimary"
     tabindex="0"
     type="button"
@@ -37,7 +39,9 @@ exports[`basic snapshot - only default props 1`] = `
 exports[`select an option 1`] = `
 <DocumentFragment>
   <button
-    class="MuiButtonBase-root MuiButton-root makeStyles-button-49 MuiButton-outlined MuiButton-outlinedPrimary"
+    aria-controls="action-menu"
+    aria-haspopup="true"
+    class="MuiButtonBase-root MuiButton-root makeStyles-button-135 MuiButton-outlined MuiButton-outlinedPrimary"
     tabindex="0"
     type="button"
   >
@@ -46,7 +50,7 @@ exports[`select an option 1`] = `
     >
       Actions
       <div
-        class="MuiBox-root MuiBox-root-74"
+        class="MuiBox-root MuiBox-root-160"
       >
         <svg
           aria-hidden="true"

--- a/package/src/components/ActionMenu/index.js
+++ b/package/src/components/ActionMenu/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ActionMenu";

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -344,6 +344,7 @@ module.exports = {
       sections: [
         generateSection({
           componentNames: [
+            "ActionMenu",
             "Button",
             "SplitButton"
           ],


### PR DESCRIPTION
Resolves #73
Impact: **minor**  
Type: **feature**

## Component

ActionMenu component based on the Catalyst button and MUI Menu components.

## Screenshots
![image](https://user-images.githubusercontent.com/42217/63549964-7078d500-c4e6-11e9-9ed4-44a17855e72d.png)

![image](https://user-images.githubusercontent.com/42217/63549941-5d660500-c4e6-11e9-8632-7a2e7e55d08b.png)


## Breaking changes

none

## Testing
1. Open the ActionMenu docs and play around with it
