### PR TITLE
fix(chip): chip height is 32; deletable chip colors are different.

### DIFF
--- a/package/src/components/Button/Button.md
+++ b/package/src/components/Button/Button.md
@@ -112,6 +112,42 @@ The error button is used for a destructive action that is difficult to recover f
 </div>
 ```
 
+#### Example
+
+##### Button groups
+
+- Follow these patterns for groups of buttons in Cards and the Primary AppBar:
+
+```jsx
+<div>
+  <Button style={{marginRight: "0.5rem"}} variant="default" color="primary">Discard</Button>
+  <Button style={{marginRight: "0.5rem"}} variant="outlined" color="primary">Save changes</Button>
+  <Button style={{marginRight: "0.5rem"}} variant="contained" color="primary">Publish</Button>
+</div>
+```
+
+```jsx
+<div>
+  <Button style={{marginRight: "0.5rem"}} variant="outlined" color="primary">Cancel</Button>
+  <Button style={{marginRight: "0.5rem"}} variant="contained" color="primary">OK</Button>
+</div>
+```
+
+
+```jsx
+<div>
+  <Button style={{marginRight: "0.5rem"}} variant="outlined" color="primary">Cancel</Button>
+  <Button style={{marginRight: "0.5rem"}} variant="contained" color="primary">Save</Button>
+</div>
+```
+
+```jsx
+<div>
+  <Button style={{marginRight: "0.5rem"}} variant="outlined" color="primary">Cancel</Button>
+  <Button style={{marginRight: "0.5rem"}} variant="contained" color="error">Delete</Button>
+</div>
+```
+
 ### API
 
 The Catalyst Button inherits from the Material-UI [Button component](https://material-ui.com/components/buttons/). Refer to the Material-UI [Button API docs](https://material-ui.com/api/button/) for more information.

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -296,7 +296,7 @@ export const rawMuiTheme = {
       root: {
         fontSize: defaultFontSize * 0.875,
         letterSpacing: captionLetterSpacing,
-        height: 30
+        height: 32
       },
       deletable: {
         "&:hover": {
@@ -304,8 +304,8 @@ export const rawMuiTheme = {
         }
       },
       deletableColorPrimary: {
-        "backgroundColor": colors.black02,
-        "border": `1px solid ${colors.black30}`,
+        "backgroundColor": colors.black05,
+        "border": `1px solid ${colors.coolGrey}`,
         "color": colors.coolGrey500,
         "&:hover, &:focus, &:active": {
           backgroundColor: colors.black05

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -304,7 +304,7 @@ export const rawMuiTheme = {
         }
       },
       deletableColorPrimary: {
-        "backgroundColor": colors.black05,
+        "backgroundColor": colors.black02,
         "border": `1px solid ${colors.coolGrey}`,
         "color": colors.coolGrey500,
         "&:hover, &:focus, &:active": {


### PR DESCRIPTION
Resolves #74 
Impact: **minor**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component: Chip
- All chips are height 32, unless they are `small`, which is 28.
- Deletable Chip (non-Select type): Background color is `colors.black05`, border is `colors.coolGrey`

## Screenshots
<img width="792" alt="Screen Shot 2019-08-22 at 2 55 43 PM" src="https://user-images.githubusercontent.com/3673236/63553005-0d8b3c00-c4ee-11e9-8d06-11d28325b72d.png">


## Breaking changes
- None

## Testing
1. Deletable chip height
1. Deletable chip colors