### PR TITLE
feat: confirmable options in ActionMenu

### DIFF
--- a/package/src/components/ActionMenu/ActionMenu.js
+++ b/package/src/components/ActionMenu/ActionMenu.js
@@ -9,6 +9,7 @@ import {
 } from "@material-ui/core";
 import ChevronDownIcon from "mdi-material-ui/ChevronDown";
 import Button from "../Button";
+import ConfirmDialog from "../ConfirmDialog";
 
 const useStyles = makeStyles((theme) => ({
   button: {
@@ -38,9 +39,10 @@ const ActionMenu = React.forwardRef(function ActionMenu(props, ref) {
    * @param {Number} index Menu item index
    * @returns {undefined}
    */
-  function handleMenuItemClick(event, index) {
+  function handleMenuItemClick({ event, index, onClick }) {
     const selectedOption = options[index];
     onSelect && onSelect(selectedOption, index);
+    onClick && onClick(event);
     setOpen(false);
   }
 
@@ -95,20 +97,62 @@ const ActionMenu = React.forwardRef(function ActionMenu(props, ref) {
             />
           </Box>
         </MenuItem>
-        {options.map(({ label, details, isDisabled }, index) => (
-          <MenuItem
-            key={index}
-            disabled={isDisabled}
-            onClick={(event) => handleMenuItemClick(event, index)}
-          >
-            <Box maxWidth={320} whiteSpace="normal">
-              <ListItemText
-                primary={label}
-                secondary={details}
-              />
-            </Box>
-          </MenuItem>
-        ))}
+        {options.map((option, index) => {
+          const {
+            label,
+            details,
+            isDisabled,
+            cancelActionText,
+            confirmActionText,
+            confirmTitle,
+            confirmMessage,
+            onClick
+          } = option;
+
+          const callback = (event) => handleMenuItemClick({ event, index, onClick });
+
+          if (confirmTitle || confirmMessage) {
+            return (
+              <ConfirmDialog
+                cancelActionText={cancelActionText}
+                confirmActionText={confirmActionText}
+                title={confirmTitle}
+                message={confirmMessage}
+                onConfirm={callback}
+              >
+                {({ openDialog }) => (
+                  <MenuItem
+                    key={index}
+                    disabled={isDisabled}
+                    onClick={openDialog}
+                  >
+                    <Box maxWidth={320} whiteSpace="normal">
+                      <ListItemText
+                        primary={label}
+                        secondary={details}
+                      />
+                    </Box>
+                  </MenuItem>
+                )}
+              </ConfirmDialog>
+            );
+          }
+
+          return (
+            <MenuItem
+              key={index}
+              disabled={isDisabled}
+              onClick={callback}
+            >
+              <Box maxWidth={320} whiteSpace="normal">
+                <ListItemText
+                  primary={label}
+                  secondary={details}
+                />
+              </Box>
+            </MenuItem>
+          );
+        })}
       </Menu>
     </Fragment>
   );
@@ -141,16 +185,45 @@ ActionMenu.propTypes = {
    */
   isWaiting: PropTypes.bool,
   /**
-   * onSelect callback when an option is selected from the menu
+   * Called when an option is selected. Can be use simultaneously with option onClick callbacks.
    */
   onSelect: PropTypes.func,
   /**
    * Menu options
    */
   options: PropTypes.arrayOf(PropTypes.shape({
+    /**
+     * Change the cancel button label in the confirm dialog
+     */
+    cancelActionText: PropTypes.string,
+    /**
+     * Change the label of the confirmation button in the confirm dialog
+     */
+    confirmActionText: PropTypes.string,
+    /**
+     * If supplied, the option will show a confirm dialog this message when selected.
+     */
+    confirmMessage: PropTypes.string,
+    /**
+     * If supplied, the option will show a confirm dialog this title when selected
+     */
+    confirmTitle: PropTypes.string,
+    /**
+     * Secondary option label
+     */
     details: PropTypes.string,
+    /**
+     * Disable the option
+     */
     isDisabled: PropTypes.bool,
-    label: PropTypes.string.isRequired
+    /**
+     * Option label
+     */
+    label: PropTypes.string.isRequired,
+    /**
+     * If supplied, this function will be called in addition to onSelect
+     */
+    onClick: PropTypes.func
   }))
 };
 

--- a/package/src/components/ActionMenu/ActionMenu.md
+++ b/package/src/components/ActionMenu/ActionMenu.md
@@ -10,23 +10,71 @@ This is basic example of how to implement the ActionMenu.
 
 ```jsx
 const options = [{
-  label: "Filter by file"
+  label: "Open"
 }, {
-  label: "Publish"
+  label: "Archived"
 }, {
-  label: "Make Visible"
+  label: "Shipped"
 }, {
-  label: "Make Hidden"
-}, {
-  label: "Duplicate"
-}, {
-  label: "Archive"
-}];
+  label: "Canceled"
+} ];
 
 <ActionMenu
   options={options}
   onSelect={(option, index) => alert(`Selected option "${option.label}" at index (${index})`)}
 >
+  Set status
+</ActionMenu>
+```
+
+### Options with confirmation
+
+ActionMenu options can be guarded with a confirmation dialog on click. To achieve this, provide either `confirmTitle` or `confirmMessage` as part of the option object. You may also supply an `onClick` handler for more control of the menu item click.
+
+```jsx
+const options = [{
+  label: "Filter by file",
+  onClick: () => {
+    console.log("Filter by file");
+  }
+}, {
+  label: "Publish",
+  confirmTitle: "Publish 32 products",
+  confirmMessage: "Are you sure you want to publish 32 products to your storefront?",
+  onClick: () => {
+    console.log("Published 32 products");
+  }
+}, {
+  label: "Make Visible",
+  confirmTitle: "Make 32 products visible",
+  confirmMessage: "Are you sure you want to make 32 products visible to customers?",
+  onClick: () => {
+    console.log("Made 32 products visible");
+  }
+}, {
+  label: "Make Hidden",
+  confirmTitle: "Make 32 products hidden",
+  confirmMessage: "Are you sure you want to make 32 products hidden from customers?",
+  onClick: () => {
+    console.log("Made 32 products hidden");
+  }
+}, {
+  label: "Duplicate",
+  confirmTitle: "Duplicate 32 products",
+  confirmMessage: "Are you sure you want to duplicate 32 products?",
+  onClick: () => {
+    console.log("Duplicated 32 products");
+  }
+}, {
+  label: "Archive",
+  confirmTitle: "Archive 32 products",
+  confirmMessage: "Are you sure you want to archive 32 products? This will hide them from both admins and customers.",
+  onClick: () => {
+    console.log("Archived 32 products");
+  }
+}];
+
+<ActionMenu options={options}>
   Actions
 </ActionMenu>
 ```

--- a/package/src/components/ActionMenu/ActionMenu.md
+++ b/package/src/components/ActionMenu/ActionMenu.md
@@ -27,9 +27,9 @@ const options = [{
 </ActionMenu>
 ```
 
-### Options with confirmation
+#### Options with confirmation
 
-ActionMenu options can be guarded with a confirmation dialog on click. To achieve this, provide either `confirmTitle` or `confirmMessage` as part of the option object. You may also supply an `onClick` handler for more control of the menu item click.
+ActionMenu options can be guarded with a confirmation dialog on selection. To achieve this, provide any combination of `confirmTitle` and `confirmMessage` as part of the option object. You may also supply an `onClick` handler to each option for more control of the "click" action. The `onSelect` callback will still fire when an item is selected. In most cases you'll want to avoid using `onSelect` and `onClick` for each option together unless you plan to do some advanced event handling using both.
 
 ```jsx
 const options = [{

--- a/package/src/components/ActionMenu/ActionMenu.test.js
+++ b/package/src/components/ActionMenu/ActionMenu.test.js
@@ -25,3 +25,50 @@ test("select an option", async () => {
   expect(onSelect).toHaveBeenCalled();
   expect(asFragment()).toMatchSnapshot();
 });
+
+test("option onClick", async () => {
+  const onClick = jest.fn();
+  const optionsWithAnOnClick = [{
+    label: "Add tags to products"
+  }, {
+    label: "Remove tags from products",
+    onClick
+  }, {
+    label: "Remove all tags",
+    isDisabled: true
+  }];
+
+  const { asFragment, getAllByText, getByText } = render(<ActionMenu options={optionsWithAnOnClick}>Actions</ActionMenu>);
+  fireEvent.click(getAllByText("Actions")[0]);
+  const removeButton = await waitForElement(() => getByText("Remove tags from products"));
+  fireEvent.click(removeButton);
+  expect(onClick).toHaveBeenCalled();
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("option onClick with confirmation", async () => {
+  const onClick = jest.fn();
+  const optionsWithAnOnClick = [{
+    label: "Add tags to products"
+  }, {
+    label: "Remove tags from products",
+    confirmTitle: "Confirm action",
+    confirmMessage: "Are you sure you want to do that?",
+    onClick
+  }, {
+    label: "Remove all tags",
+    isDisabled: true
+  }];
+
+  const { asFragment, getAllByText, getByText } = render(<ActionMenu options={optionsWithAnOnClick}>Actions</ActionMenu>);
+  // Open the menu
+  fireEvent.click(getAllByText("Actions")[0]);
+  // Wait for open, then get the "Remove tags from products" button
+  const removeButton = await waitForElement(() => getByText("Remove tags from products"));
+  fireEvent.click(removeButton);
+  // Wait for dialog to open then click the OK button
+  const dialogConfirmButton = await waitForElement(() => getByText("OK"));
+  fireEvent.click(dialogConfirmButton);
+  expect(onClick).toHaveBeenCalled();
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/package/src/components/ActionMenu/__snapshots__/ActionMenu.test.js.snap
+++ b/package/src/components/ActionMenu/__snapshots__/ActionMenu.test.js.snap
@@ -36,6 +36,78 @@ exports[`basic snapshot - only default props 1`] = `
 </DocumentFragment>
 `;
 
+exports[`option onClick 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="action-menu"
+    aria-haspopup="true"
+    class="MuiButtonBase-root MuiButton-root makeStyles-button-269 MuiButton-outlined MuiButton-outlinedPrimary"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      Actions
+      <div
+        class="MuiBox-root MuiBox-root-294"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+          />
+        </svg>
+      </div>
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</DocumentFragment>
+`;
+
+exports[`option onClick with confirmation 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="action-menu"
+    aria-haspopup="true"
+    class="MuiButtonBase-root MuiButton-root makeStyles-button-403 MuiButton-outlined MuiButton-outlinedPrimary"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      Actions
+      <div
+        class="MuiBox-root MuiBox-root-428"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+          />
+        </svg>
+      </div>
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</DocumentFragment>
+`;
+
 exports[`select an option 1`] = `
 <DocumentFragment>
   <button


### PR DESCRIPTION
Resolves #84
Impact: **minor**  
Type: **feature**

## Component

`ActionMenu` meets `ConfirmDialog`. It's now possible to declare options as `confirmable` by supplying `confirmTitle` and/or `confirmMessage`, which will show a `ConfirmDialog` when the item is selected.

Also, allow defining an `onClick` method for each option.

## Screenshots

![image](https://user-images.githubusercontent.com/42217/63965263-9dc90400-ca4d-11e9-8d76-fc18da5efb50.png)

## Breaking changes

none

## Testing
1. Check the docs here: https://deploy-preview-85--heuristic-perlman-0ef024.netlify.com/#/Components/Actions/ActionMenu
2. Play around with the "Options with confirmation" example
3. "Filter by file" is not guarded, while the rest the options are
