### PR TITLE
fix(select): use useTheme for IndicatorSeparator

### DIFF
--- a/package/src/components/Select/Select.js
+++ b/package/src/components/Select/Select.js
@@ -134,7 +134,7 @@ const Select = React.forwardRef(function Select(props, ref) {
           borderRadius: 0,
           colors: {
             ...theme.colors,
-            neutral20: "#3c3c3c"
+            neutral20: theme.palette.colors.coolGrey500
           }
         })}
         {...otherProps}

--- a/package/src/components/Select/helpers/IndicatorSeparator.js
+++ b/package/src/components/Select/helpers/IndicatorSeparator.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import defaultTheme from "../../../theme/defaultTheme";
+import { useTheme } from "@material-ui/core/styles";
 
 /**
  * @name IndicatorSeparator
@@ -8,9 +8,10 @@ import defaultTheme from "../../../theme/defaultTheme";
  * @returns {React.Component} A React component
  */
 export default function IndicatorSeparator(props) {
+  const theme = useTheme();
   const indicatorSeparatorStyle = {
     alignSelf: "stretch",
-    backgroundColor: defaultTheme.palette.colors.black20,
+    backgroundColor: theme.palette.colors.black20,
     marginBottom: 8,
     marginTop: 8,
     width: 1


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Resolves none
Impact: **major**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component: Select
- IndicatorSeparator: use `useTheme`
- Select: remove hardcoded color and use `theme` variable

## Screenshots
Confirms the colors of the arrow, V, or the separator, |,  have not changed:
<img width="1440" alt="Screen Shot 2019-08-29 at 2 12 49 PM" src="https://user-images.githubusercontent.com/3673236/63976891-391aa300-ca67-11e9-9c97-90bb09ff7031.png">


## Breaking changes
None

## Testing
1. Test that this works in Reaction Admin
1. Test that the visual style has not changed