### PR TITLE
fix(select): remove props from indicatorselector

### DIFF
--- a/package/src/components/Select/__snapshots__/Select.test.js.snap
+++ b/package/src/components/Select/__snapshots__/Select.test.js.snap
@@ -56,10 +56,7 @@ exports[`basic snapshot test 1`] = `
               class=" css-1wy0on6"
             >
               <span
-                options="[object Object],[object Object],[object Object]"
-                selectprops="[object Object]"
                 style="align-self: stretch; background-color: rgb(204, 204, 204); margin-bottom: 8px; margin-top: 8px; width: 1px;"
-                theme="[object Object]"
               />
               <div
                 aria-hidden="true"

--- a/package/src/components/Select/helpers/IndicatorSeparator.js
+++ b/package/src/components/Select/helpers/IndicatorSeparator.js
@@ -1,10 +1,8 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { useTheme } from "@material-ui/core/styles";
 
 /**
  * @name IndicatorSeparator
- * @param {Object} props Component props
  * @returns {React.Component} A React component
  */
 export default function IndicatorSeparator() {
@@ -18,6 +16,6 @@ export default function IndicatorSeparator() {
   };
 
   return (
-    <span style={indicatorSeparatorStyle}/>
+    <span style={indicatorSeparatorStyle} />
   );
 }

--- a/package/src/components/Select/helpers/IndicatorSeparator.js
+++ b/package/src/components/Select/helpers/IndicatorSeparator.js
@@ -7,7 +7,7 @@ import { useTheme } from "@material-ui/core/styles";
  * @param {Object} props Component props
  * @returns {React.Component} A React component
  */
-export default function IndicatorSeparator(props) {
+export default function IndicatorSeparator() {
   const theme = useTheme();
   const indicatorSeparatorStyle = {
     alignSelf: "stretch",
@@ -18,10 +18,6 @@ export default function IndicatorSeparator(props) {
   };
 
   return (
-    <span style={indicatorSeparatorStyle} {...props} />
+    <span style={indicatorSeparatorStyle}/>
   );
 }
-
-IndicatorSeparator.propTypes = {
-  props: PropTypes.object.isRequired
-};


### PR DESCRIPTION
Resolves none
Impact: **minor**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component: IndicatorSelector
Inner props are unnecessary for this component.

## Breaking changes
None

## Testing
1. Check to ensure it works in Reaction Admin w/o any console logs/errors/warnings
