### PR TITLE
fix(sidebar): fix border overrides

### DIFF
--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -403,12 +403,13 @@ export const rawMuiTheme = {
         width: drawerWidth
       },
       paperAnchorLeft: {
-        borderRight: "none",
+        border: "none",
         backgroundColor: colors.darkBlue500,
         color: colors.black15
       },
       paperAnchorDockedLeft: {
-        border: "none"
+        border: "none",
+        borderRight: "none"
       },
       paperAnchorRight: {
         border: "none",


### PR DESCRIPTION
#90 

## Component: Default Theme + Sidebar

This white/grey border bug still exists on Reaction Admin:

Tablet mode
<img width="346" alt="Screen Shot 2019-08-30 at 1 51 24 PM" src="https://user-images.githubusercontent.com/3673236/64050559-48642400-cb2d-11e9-8aaa-e7ace5c2e719.png">

Desktop
<img width="67" alt="Screen Shot 2019-08-30 at 1 50 23 PM" src="https://user-images.githubusercontent.com/3673236/64050517-22d71a80-cb2d-11e9-9d7f-cd28f0055a2d.png">
<img width="593" alt="Screen Shot 2019-08-30 at 1 50 36 PM" src="https://user-images.githubusercontent.com/3673236/64050522-28ccfb80-cb2d-11e9-94e5-a56c5c6c5fa0.png">



## Fix

Confirmed by running Reaction Admin locally w/ this branch:
<img width="1440" alt="Screen Shot 2019-08-30 at 1 48 00 PM" src="https://user-images.githubusercontent.com/3673236/64050495-10f57780-cb2d-11e9-9595-5fef0b88e3b1.png">
<img width="732" alt="Screen Shot 2019-08-30 at 1 48 03 PM" src="https://user-images.githubusercontent.com/3673236/64050496-10f57780-cb2d-11e9-9f54-3145cfa8af4c.png">
