### PR TITLE
fix(card): correct padding top and secondary text color

### DIFF
--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -315,10 +315,14 @@ export const rawMuiTheme = {
       }
     },
     MuiCardHeader: {
+      root: {
+        paddingTop: defaultSpacingUnit * 3
+      },
       title: {
         fontWeight: fontWeightSemiBold
       },
       subheader: {
+        color: colors.coolGrey500,
         marginLeft: defaultSpacingUnit * 2
       }
     },

--- a/styleguide/src/sections/Card.md
+++ b/styleguide/src/sections/Card.md
@@ -4,6 +4,8 @@ Use Material-UI's Card with icons from `mdi-material-ui` and Catalyst's default 
 
 #### Basic Card
 
+- Card with title and subheader
+
 ```jsx
 import { Card, CardHeader, CardContent, Typography } from "@material-ui/core";
 
@@ -13,12 +15,48 @@ import { Card, CardHeader, CardContent, Typography } from "@material-ui/core";
     subheader="1239 products"
   />
   <CardContent>
-    <Typography variant="body2">Help text goes here</Typography>
+    <Typography variant="body1">Ipsam ipsum harum iusto sint. Voluptas animi quaerat voluptate laudantium iure quasi est. Nemo ducimus nemo blanditiis explicabo eos velit. Aut eos ab quis asperiores ab esse ex est. Asperiores ut officia sed necessitatibus porro dolorem eligendi qui. Dolores quod sit accusamus impedit ipsam neque animi.</Typography>
+  </CardContent>
+</Card>
+```
+
+- Card with ActionMenu
+
+```jsx
+import { Card, CardHeader, CardContent, Typography } from "@material-ui/core";
+import ActionMenu from "../../../package/src/components/ActionMenu";
+
+const options = [{
+  label: "Open"
+}, {
+  label: "Archived"
+}, {
+  label: "Shipped"
+}, {
+  label: "Canceled"
+} ];
+
+<Card>
+  <CardHeader
+    title="All products"
+    subheader="1239 products"
+  />
+  <ActionMenu
+    style={{marginTop: "16px", marginLeft: "16px", marginBottom: "16px"}}
+    options={options}
+    onSelect={(option, index) => alert(`Selected option "${option.label}" at index (${index})`)}
+  >
+    Actions
+  </ActionMenu>
+  <CardContent>
+    <Typography variant="body1">Ipsam ipsum harum iusto sint. Voluptas animi quaerat voluptate laudantium iure quasi est. Nemo ducimus nemo blanditiis explicabo eos velit. Aut eos ab quis asperiores ab esse ex est. Asperiores ut officia sed necessitatibus porro dolorem eligendi qui. Dolores quod sit accusamus impedit ipsam neque animi.</Typography>
   </CardContent>
 </Card>
 ```
 
 #### Quick Edit Card
+
+- With title
 
 ```jsx
 import { Card, CardHeader, CardContent, IconButton, Typography } from "@material-ui/core";
@@ -26,8 +64,29 @@ import CloseIcon from "mdi-material-ui/Close";
 
 <Card>
   <CardHeader
-    title="All products"
-    subheader="1239 products"
+    title="Filter products by file"
+    action={
+      <IconButton aria-label="close">
+        <CloseIcon/>
+      </IconButton>
+    }
+  />
+  <CardContent>
+    <Typography variant="body2">Help text goes here</Typography>
+  </CardContent>
+</Card>
+```
+
+- With title and secondary title
+
+```jsx
+import { Card, CardHeader, CardContent, IconButton, Typography } from "@material-ui/core";
+import CloseIcon from "mdi-material-ui/Close";
+
+<Card>
+  <CardHeader
+    title="Add/remove tags"
+    subheader="1022 selected"
     action={
       <IconButton aria-label="close">
         <CloseIcon/>


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Resolves #91 
Resolves #90
Impact: **minor**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component: Card
- Top padding b/w Title and border should be 32px
- Secondary text color should be coolGrey500
Note: For Quick Edit cards (Card that have an X), the top padding will still be a little off, b/c of the padding change that the X adds. This will be addressed in a future ticket.

## Screenshots
Confirmed on Reaction Admin locally:
<img width="623" alt="Screen Shot 2019-08-30 at 2 33 45 PM" src="https://user-images.githubusercontent.com/3673236/64052508-9ed46100-cb33-11e9-9e86-ef3b927563d5.png">
Secondary text color and top padding is now correct.

## Breaking changes
none

## Testing
1. Look at examples in branch deploy
1. Use in Reaction Admin's Product Table tag to confirm fix