### PR TITLE
fix(dialogtitle): title should be semibold

### DIFF
--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -385,7 +385,10 @@ export const rawMuiTheme = {
     },
     MuiDialogTitle: {
       root: {
-        padding: defaultTheme.spacing(4, 4, 1, 4)
+        "padding": defaultTheme.spacing(4, 4, 1, 4),
+        "& h2": {
+          fontWeight: fontWeightSemiBold
+        }
       }
     },
     MuiDialogContent: {


### PR DESCRIPTION
Resolves #95 
Impact: **minor**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component: DialogTitle for ConfirmDialog
- Type should be semibold

## Screenshots

<img width="703" alt="Screen Shot 2019-08-29 at 9 22 34 PM" src="https://user-images.githubusercontent.com/3673236/63992952-2756f100-caa3-11e9-929e-db651d910c79.png">

## Breaking changes
None

## Testing
1. Test individually
1. Test in the ConfirmDialog