### PR TITLE
docs(status): update Navigation structure; add Component status page

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -325,19 +325,19 @@ module.exports = {
       name: "Getting started",
       sections: [
         {
-          name: "Installation",
+          name: "Install",
           content: "styleguide/src/sections/Installation.md"
         },
         {
-          name: "Theming",
+          name: "Theme components",
           content: "styleguide/src/sections/Theming.md"
         },
         {
-          name: "Developing Locally Inside Another Project",
+          name: "Develop locally",
           content: "styleguide/src/sections/LocalDevelopment.md"
         },
         {
-          name: "Understanding Component References",
+          name: "Component references",
           content: "styleguide/src/sections/ComponentsContext.md"
         }
       ],

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -333,7 +333,7 @@ module.exports = {
           content: "styleguide/src/sections/Theming.md"
         },
         {
-          name: "Develop locally",
+          name: "Develop locally within an app",
           content: "styleguide/src/sections/LocalDevelopment.md"
         },
         {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -297,22 +297,18 @@ module.exports = {
   },
   sections: [
     {
-      name: "Introduction",
+      name: "Overview",
       content: "styleguide/src/sections/Introduction.md",
       sections: [
         {
-          name: "Installation",
-          content: "styleguide/src/sections/Installation.md"
-        },
-        {
-          name: "Understanding Component References",
-          content: "styleguide/src/sections/ComponentsContext.md"
+          name: "Component status",
+          content: "styleguide/src/sections/Status.md"
         }
       ],
       sectionDepth: 2
     },
     {
-      name: "Designers",
+      name: "Foundations",
       sections: [
         {
           name: "Colors",
@@ -326,8 +322,12 @@ module.exports = {
       sectionDepth: 2
     },
     {
-      name: "Developers",
+      name: "Getting started",
       sections: [
+        {
+          name: "Installation",
+          content: "styleguide/src/sections/Installation.md"
+        },
         {
           name: "Theming",
           content: "styleguide/src/sections/Theming.md"
@@ -335,6 +335,10 @@ module.exports = {
         {
           name: "Developing Locally Inside Another Project",
           content: "styleguide/src/sections/LocalDevelopment.md"
+        },
+        {
+          name: "Understanding Component References",
+          content: "styleguide/src/sections/ComponentsContext.md"
         }
       ],
       sectionDepth: 2

--- a/styleguide/src/sections/Introduction.md
+++ b/styleguide/src/sections/Introduction.md
@@ -6,7 +6,7 @@ Introducing Reaction Commerce's **Catalyst Design System** and the `@reactioncom
 
 #### Developers
 
-- Use the documentation here to learn how to [install and import components](/#/Introduction/Installation/) with the [NPM package](https://www.npmjs.com/package/@reactioncommerce/catalyst) and [theme components](/#/Developers/Theming).
+- Use the documentation here to learn how to install, theme and use these components.
 - Use the [GitHub documentation](https://github.com/reactioncommerce/catalyst/blob/master/docs/README.md) for instructions on how to contribute to this package and the docs.
 
 #### Contribute

--- a/styleguide/src/sections/Status.md
+++ b/styleguide/src/sections/Status.md
@@ -1,0 +1,13 @@
+Tracking the design, development and usage of new Catalyst components in Reaction Admin:
+
+| Component     | Type               | Catalyst release | Reaction release |
+|---------------|--------------------|------------------|------------------|
+| **ActionMenu**    | Catalyst           | 1.8              | 2.2              |
+| **Button**        | Catalyst           | 1.1              | 2.1              |
+| **Card**          | Themed by Catalyst | 1.9              | 2.3              |
+| **Chip**          | Catalyst           | 1.4              | 2.2              |
+| **ConfirmDialog** | Catalyst           | 1.2              | 2.1              |
+| **Select, MultiSelect**        | Catalyst           | 1.7              | 2.3              |
+| **SplitButton**   | Catalyst           | 1.5              | 2.2              |
+| **Tab**           | Themed by Catalyst | 1.9              | 2.3              |
+| **Typography**    | Themed by Catalyst | 1.7              | 2.2              |

--- a/styleguide/src/styles.css
+++ b/styleguide/src/styles.css
@@ -41,3 +41,7 @@ body {
   width: 100%;
   margin-bottom: 15px;
 }
+
+.rsg--button-21 {
+  display: none;
+}


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Resolves #64 
Impact: **minor**  
Type: **docs**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Documentation:
- Rename `Introduction` to `Overview`
- Add `Component status` page with the latest Reaction and Catalyst release data
- Style remove that [ ] square icon thing
- Title case all titles


<img width="1082" alt="Screen Shot 2019-08-30 at 12 15 06 PM" src="https://user-images.githubusercontent.com/3673236/64046095-d3d6b880-cb1f-11e9-96a8-6a064bdfc4ca.png">

## Testing
1. Check the sidenav
1. Check the status page