### PR TITLE
fix(splitbutton): disable menulist padding

### DIFF
--- a/package/src/components/SplitButton/SplitButton.js
+++ b/package/src/components/SplitButton/SplitButton.js
@@ -107,7 +107,7 @@ const SplitButton = React.forwardRef(function SplitButton(props, ref) {
           >
             <Paper elevation={2} id="menu-list-grow">
               <ClickAwayListener onClickAway={handleClose}>
-                <MenuList>
+                <MenuList disablePadding>
                   {options.map(({ label, details, isDisabled }, index) => (
                     <MenuItem
                       key={label}


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Resolves #89 
Impact: **minor**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component: SplitButton
SplitButton should not have padding above/below the MenuItems.

Alternate option: MenuList's padding could be disabled by default in the theme with props, b/c I've confirmed with @cassytaylor that the SplitButton, ActionMenu and other MenuLists used in the app  should not have this padding. 

## Screenshots
<img width="342" alt="Screen Shot 2019-08-30 at 1 21 54 PM" src="https://user-images.githubusercontent.com/3673236/64049280-2799cf80-cb29-11e9-9a9a-31fadef6878d.png">

## Breaking changes
none

## Testing
1. Check SplitButton padding