### PR TITLE
fix(button): text-only button should be 40px

### DIFF
--- a/package/src/components/Button/Button.md
+++ b/package/src/components/Button/Button.md
@@ -120,7 +120,7 @@ The error button is used for a destructive action that is difficult to recover f
 
 ```jsx
 <div>
-  <Button style={{marginRight: "0.5rem"}} variant="default" color="primary">Discard</Button>
+  <Button style={{marginRight: "0.5rem"}} variant="text" color="primary">Discard</Button>
   <Button style={{marginRight: "0.5rem"}} variant="outlined" color="primary">Save changes</Button>
   <Button style={{marginRight: "0.5rem"}} variant="contained" color="primary">Publish</Button>
 </div>

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -266,10 +266,14 @@ export const rawMuiTheme = {
         textTransform: "initial"
       },
       text: {
-        color: colors.coolGrey400,
-        fontWeight: fontWeightRegular,
-        fontSize: defaultFontSize * 0.875,
-        padding: `${defaultSpacingUnit}px ${defaultSpacingUnit * 2}px`
+        "color": colors.coolGrey400,
+        "fontWeight": fontWeightRegular,
+        "fontSize": defaultFontSize * 0.875,
+        "padding": `${defaultSpacingUnit}px ${defaultSpacingUnit * 2}px`,
+        "border": "1.5px solid transparent",
+        "& hover": {
+          border: `1.5px solid ${colors.coolGrey100}`
+        }
       },
       outlined: {
         // Removed 1px of padding from the top/bottom to account for the border

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -266,14 +266,10 @@ export const rawMuiTheme = {
         textTransform: "initial"
       },
       text: {
-        "color": colors.coolGrey400,
-        "fontWeight": fontWeightRegular,
-        "fontSize": defaultFontSize * 0.875,
-        "padding": `${defaultSpacingUnit}px ${defaultSpacingUnit * 2}px`,
-        "border": "1.5px solid transparent",
-        "& hover": {
-          border: `1.5px solid ${colors.coolGrey100}`
-        }
+        color: colors.coolGrey400,
+        fontWeight: fontWeightRegular,
+        fontSize: defaultFontSize * 0.875,
+        padding: `${defaultSpacingUnit + 1.5}px ${defaultSpacingUnit * 2}px`
       },
       outlined: {
         // Removed 1px of padding from the top/bottom to account for the border

--- a/styleguide/src/styles.css
+++ b/styleguide/src/styles.css
@@ -42,6 +42,7 @@ body {
   margin-bottom: 15px;
 }
 
-.rsg--button-21 {
+[data-testid="Button-isolate-button"],
+[aria-label="Open isolated"] {
   display: none;
 }


### PR DESCRIPTION
Resolves #98 
Impact: **minor**  
Type: **bugfix|docs**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component: Button, text-only type
- Add 1.5px to total height so that height is at 40px

## Screenshots
<img width="603" alt="Screen Shot 2019-08-30 at 4 07 32 PM" src="https://user-images.githubusercontent.com/3673236/64055271-4eafcb80-cb40-11e9-9e67-11b5f7294832.png">
<img width="674" alt="Screen Shot 2019-08-30 at 4 07 37 PM" src="https://user-images.githubusercontent.com/3673236/64055272-4f486200-cb40-11e9-8100-a01a11ff44fc.png">


## Breaking changes
none

## Testing
1. Test a Text only button next to a Contained or Outlined one, and compare their heights