### PR TITLE
chore: remove snyk-security step from workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,10 +226,6 @@ workflows:
           context: reaction-validation
           requires:
             - docker-build
-      - snyk-security:
-          context: reaction-validation
-          requires:
-            - docker-build
       - publish-npm-package:
           context: reaction-publish-semantic-release
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,30 +168,6 @@ jobs:
       - store_artifacts:
           path: reports
 
-  snyk-security:
-    <<: *defaults
-    steps:
-      - setup_remote_docker
-      - attach_workspace:
-          at: docker-cache
-      - run:
-          name: Load Docker Image
-          command: |
-            docker load < docker-cache/docker-image.tar
-      - run:
-          name: Snyk
-          command: |
-            # Snyk doesn't look up the directory tree for node_modules as
-            # NodeJS does so we have to take some extra measures to test in the
-            # Docker image. Copy package.json up a directory so that it is a
-            # sibling to node_modules, then run snyk test.
-            docker run \
-              --env-file docker-cache/.env \
-              -e "SNYK_TOKEN=$SNYK_TOKEN" \
-              --name reactionapp_web_1 \
-              "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
-              sh -c "snyk test"
-
   publish-npm-package:
     docker:
       - image: node:8
@@ -231,7 +207,6 @@ workflows:
           requires:
             - lint
             - test
-            - snyk-security
           filters:
             branches:
               only: master


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Resolves #105 
Impact: **major**  
Type: **chore**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->
## Issue
- Remove Snyk as a CI build step

## Testing
