### PR TITLE
docs(card): add Card with Grow example

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -381,6 +381,10 @@ module.exports = {
               content: "styleguide/src/sections/Card.md"
             },
             {
+              name: "Quick Edit Card",
+              content: "styleguide/src/sections/QuickEditCard.md"
+            },
+            {
               name: "Tabs",
               content: "styleguide/src/sections/Tabs.md"
             }

--- a/styleguide/src/sections/QuickEditCard.md
+++ b/styleguide/src/sections/QuickEditCard.md
@@ -1,7 +1,7 @@
 #### Slide
 
 ```jsx
-import { Card, CardHeader, CardContent, IconButton, Typography, Slide, FormControlLabel, Switch } from "@material-ui/core";
+import { Card, CardHeader, CardContent, Grid, IconButton, Typography, Slide, FormControlLabel, Switch } from "@material-ui/core";
 import CloseIcon from "mdi-material-ui/Close";
 import Button from "../../../package/src/components/Button";
 
@@ -13,28 +13,40 @@ function SlideCard() {
   }
 
   return (
-    <div>
-      <Slide direction="down" timeout={200} in={checked} mountOnEnter unmountOnExit>
+    <Grid container spacing={3}>
+      <Grid item xs={12}>
+        <Slide direction="down" timeout={200} in={checked} mountOnEnter unmountOnExit>
+          <Card>
+            <CardHeader
+              title="Add/remove tags"
+              subheader="1022 selected"
+              action={
+                <IconButton aria-label="close" onClick={() => handleChange()}>
+                  <CloseIcon/>
+                </IconButton>
+              }
+            />
+            <CardContent>
+              <Typography variant="body2">Help text goes here</Typography>
+            </CardContent>
+          </Card>
+        </Slide>
+      </Grid>
+      <Grid item xs={12}>
         <Card>
           <CardHeader
-            title="Add/remove tags"
-            subheader="1022 selected"
-            action={
-              <IconButton aria-label="close" onClick={() => handleChange()}>
-                <CloseIcon/>
-              </IconButton>
-            }
+            title="All products"
+            subheader="1239 products"
           />
           <CardContent>
-            <Typography variant="body2">Help text goes here</Typography>
+            <FormControlLabel
+              control={<Switch checked={checked} onChange={handleChange} />}
+              label="Show Quick Edit card"
+            />
           </CardContent>
         </Card>
-      </Slide>
-      <FormControlLabel
-        control={<Switch checked={checked} onChange={handleChange} />}
-        label="Show"
-      />
-    </div>
+      </Grid>
+    </Grid>
   )
 }
 
@@ -44,7 +56,7 @@ function SlideCard() {
 #### Fade
 
 ```jsx
-import { Card, CardHeader, CardContent, IconButton, Typography, Fade, FormControlLabel, Switch } from "@material-ui/core";
+import { Card, CardHeader, CardContent, Grid, IconButton, Typography, Fade, FormControlLabel, Switch } from "@material-ui/core";
 import CloseIcon from "mdi-material-ui/Close";
 import Button from "../../../package/src/components/Button";
 
@@ -56,28 +68,40 @@ function FadeCard() {
   }
 
   return (
-    <div>
-      <Fade timeout={100} in={checked} mountOnEnter unmountOnExit>
+    <Grid container spacing={3}>
+      <Grid item xs={12}>
+        <Fade timeout={100} in={checked} mountOnEnter unmountOnExit>
+          <Card>
+            <CardHeader
+              title="Add/remove tags"
+              subheader="1022 selected"
+              action={
+                <IconButton aria-label="close" onClick={() => handleChange()}>
+                  <CloseIcon/>
+                </IconButton>
+              }
+            />
+            <CardContent>
+              <Typography variant="body2">Help text goes here</Typography>
+            </CardContent>
+          </Card>
+        </Fade>
+      </Grid>
+      <Grid item xs={12}>
         <Card>
           <CardHeader
-            title="Add/remove tags"
-            subheader="1022 selected"
-            action={
-              <IconButton aria-label="close" onClick={() => handleChange()}>
-                <CloseIcon/>
-              </IconButton>
-            }
+            title="All products"
+            subheader="1239 products"
           />
           <CardContent>
-            <Typography variant="body2">Help text goes here</Typography>
+            <FormControlLabel
+              control={<Switch checked={checked} onChange={handleChange} />}
+              label="Show Quick Edit card"
+            />
           </CardContent>
         </Card>
-      </Fade>
-      <FormControlLabel
-        control={<Switch checked={checked} onChange={handleChange} />}
-        label="Show"
-      />
-    </div>
+      </Grid>
+    </Grid>
   )
 }
 

--- a/styleguide/src/sections/QuickEditCard.md
+++ b/styleguide/src/sections/QuickEditCard.md
@@ -1,0 +1,40 @@
+```jsx
+import { Card, CardHeader, CardContent, IconButton, Typography, Slide, FormControlLabel, Switch } from "@material-ui/core";
+import CloseIcon from "mdi-material-ui/Close";
+import Button from "../../../package/src/components/Button";
+
+function SlideCard() {
+  const [checked, setChecked] = React.useState(false);
+
+  function handleChange() {
+    setChecked((prev) => !prev);
+  }
+
+  return (
+    <div>
+      <Slide direction="down" timeout={300} in={checked} mountOnEnter unmountOnExit>
+        <Card>
+          <CardHeader
+            title="Add/remove tags"
+            subheader="1022 selected"
+            action={
+              <IconButton aria-label="close" onClick={() => handleChange()}>
+                <CloseIcon/>
+              </IconButton>
+            }
+          />
+          <CardContent>
+            <Typography variant="body2">Help text goes here</Typography>
+          </CardContent>
+        </Card>
+      </Slide>
+      <FormControlLabel
+        control={<Switch checked={checked} onChange={handleChange} />}
+        label="Show"
+      />
+    </div>
+  )
+}
+
+<SlideCard />
+```

--- a/styleguide/src/sections/QuickEditCard.md
+++ b/styleguide/src/sections/QuickEditCard.md
@@ -1,3 +1,5 @@
+#### Slide
+
 ```jsx
 import { Card, CardHeader, CardContent, IconButton, Typography, Slide, FormControlLabel, Switch } from "@material-ui/core";
 import CloseIcon from "mdi-material-ui/Close";
@@ -12,7 +14,7 @@ function SlideCard() {
 
   return (
     <div>
-      <Slide direction="down" timeout={300} in={checked} mountOnEnter unmountOnExit>
+      <Slide direction="down" timeout={200} in={checked} mountOnEnter unmountOnExit>
         <Card>
           <CardHeader
             title="Add/remove tags"
@@ -37,4 +39,47 @@ function SlideCard() {
 }
 
 <SlideCard />
+```
+
+#### Fade
+
+```jsx
+import { Card, CardHeader, CardContent, IconButton, Typography, Fade, FormControlLabel, Switch } from "@material-ui/core";
+import CloseIcon from "mdi-material-ui/Close";
+import Button from "../../../package/src/components/Button";
+
+function FadeCard() {
+  const [checked, setChecked] = React.useState(false);
+
+  function handleChange() {
+    setChecked((prev) => !prev);
+  }
+
+  return (
+    <div>
+      <Fade timeout={100} in={checked} mountOnEnter unmountOnExit>
+        <Card>
+          <CardHeader
+            title="Add/remove tags"
+            subheader="1022 selected"
+            action={
+              <IconButton aria-label="close" onClick={() => handleChange()}>
+                <CloseIcon/>
+              </IconButton>
+            }
+          />
+          <CardContent>
+            <Typography variant="body2">Help text goes here</Typography>
+          </CardContent>
+        </Card>
+      </Fade>
+      <FormControlLabel
+        control={<Switch checked={checked} onChange={handleChange} />}
+        label="Show"
+      />
+    </div>
+  )
+}
+
+<FadeCard />
 ```

--- a/styleguide/src/sections/QuickEditCard.md
+++ b/styleguide/src/sections/QuickEditCard.md
@@ -1,11 +1,9 @@
-#### Slide
-
 ```jsx
-import { Card, CardHeader, CardContent, Grid, IconButton, Typography, Slide, FormControlLabel, Switch } from "@material-ui/core";
+import { Card, CardHeader, CardContent, Grid, IconButton, Typography, Grow, FormControlLabel, Switch } from "@material-ui/core";
 import CloseIcon from "mdi-material-ui/Close";
 import Button from "../../../package/src/components/Button";
 
-function SlideCard() {
+function GrowCard() {
   const [checked, setChecked] = React.useState(false);
 
   function handleChange() {
@@ -15,7 +13,7 @@ function SlideCard() {
   return (
     <Grid container spacing={3}>
       <Grid item xs={12}>
-        <Slide direction="down" timeout={200} in={checked} mountOnEnter unmountOnExit>
+        <Grow timeout={180} in={checked} mountOnEnter unmountOnExit style={{ transformOrigin: "center top" }}>
           <Card>
             <CardHeader
               title="Add/remove tags"
@@ -30,7 +28,7 @@ function SlideCard() {
               <Typography variant="body2">Help text goes here</Typography>
             </CardContent>
           </Card>
-        </Slide>
+        </Grow>
       </Grid>
       <Grid item xs={12}>
         <Card>
@@ -50,60 +48,5 @@ function SlideCard() {
   )
 }
 
-<SlideCard />
-```
-
-#### Fade
-
-```jsx
-import { Card, CardHeader, CardContent, Grid, IconButton, Typography, Fade, FormControlLabel, Switch } from "@material-ui/core";
-import CloseIcon from "mdi-material-ui/Close";
-import Button from "../../../package/src/components/Button";
-
-function FadeCard() {
-  const [checked, setChecked] = React.useState(false);
-
-  function handleChange() {
-    setChecked((prev) => !prev);
-  }
-
-  return (
-    <Grid container spacing={3}>
-      <Grid item xs={12}>
-        <Fade timeout={100} in={checked} mountOnEnter unmountOnExit>
-          <Card>
-            <CardHeader
-              title="Add/remove tags"
-              subheader="1022 selected"
-              action={
-                <IconButton aria-label="close" onClick={() => handleChange()}>
-                  <CloseIcon/>
-                </IconButton>
-              }
-            />
-            <CardContent>
-              <Typography variant="body2">Help text goes here</Typography>
-            </CardContent>
-          </Card>
-        </Fade>
-      </Grid>
-      <Grid item xs={12}>
-        <Card>
-          <CardHeader
-            title="All products"
-            subheader="1239 products"
-          />
-          <CardContent>
-            <FormControlLabel
-              control={<Switch checked={checked} onChange={handleChange} />}
-              label="Show Quick Edit card"
-            />
-          </CardContent>
-        </Card>
-      </Grid>
-    </Grid>
-  )
-}
-
-<FadeCard />
+<GrowCard />
 ```


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Resolves #107 
Impact: **minor**  
Type: **bugfix|docs**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component: Card
- Add example of Quick Edit card with animation when it opens and closes

## Screenshots
Look at the branch deploy

## Breaking changes
No

## Testing
1. Open a card
2. Close a card
