### PR TITLE
feat: DataTable row click

### DIFF
--- a/package/src/components/DataTable/DataTable.js
+++ b/package/src/components/DataTable/DataTable.js
@@ -41,6 +41,9 @@ const useStyles = makeStyles((theme) => ({
     marginTop: 0,
     marginBottom: 0
   },
+  tableRowClickable: {
+    cursor: "pointer"
+  },
   tableRowHover: {
     "&:hover": {
       backgroundColor: theme.palette.colors.black05
@@ -67,6 +70,7 @@ const DataTable = React.forwardRef(function DataTable(props, ref) {
     actionMenuProps,
     ToolbarComponent,
     PaginationComponent,
+    onRowClick,
 
     // Props unique from the useDataTable hook
     isSelectable,
@@ -90,6 +94,12 @@ const DataTable = React.forwardRef(function DataTable(props, ref) {
 
   const classes = useStyles();
   const shouldShowStandardToolbar = (actionMenuProps || isFilterable);
+
+  const handleCellClick = React.useCallback((isClickDisabled) => (event) => {
+    if (isClickDisabled) {
+      event.stopPropagation();
+    }
+  }, []);
 
   return (
     <>
@@ -134,24 +144,31 @@ const DataTable = React.forwardRef(function DataTable(props, ref) {
           {page.map((row, index) =>
             prepareRow(row) || (
               <TableRow
+                onClick={onRowClick && onRowClick(row)}
                 {...row.getRowProps()}
                 className={clsx({
                   [classes.tableRowHover]: true,
                   [classes.tableRowSelected]: row.isSelected,
-                  [classes.tableRowOdd]: !row.isSelected && ((index + 1) % 2 !== 0)
+                  [classes.tableRowOdd]: !row.isSelected && ((index + 1) % 2 !== 0),
+                  [classes.tableRowClickable]: onRowClick
                 })}
               >
-                {row.cells.map((cell) => (
-                  <TableCell
-                    padding={isSelectable ? "checkbox" : "default"}
-                    classes={{
-                      root: classes.tableCell
-                    }}
-                    {...cell.getCellProps()}
-                  >
-                    {cell.render("Cell")}
-                  </TableCell>
-                ))}
+                {row.cells.map((cell) => {
+                  const { isClickDisabled, ...cellProps } = cell.getCellProps();
+
+                  return (
+                    <TableCell
+                      onClick={handleCellClick(isClickDisabled)}
+                      // padding={isSelectable ? "checkbox" : "default"}
+                      classes={{
+                        root: classes.tableCell
+                      }}
+                      {...cellProps}
+                    >
+                      {cell.render("Cell")}
+                    </TableCell>
+                  );
+                })}
               </TableRow>
             ))}
         </TableBody>
@@ -306,6 +323,10 @@ DataTable.propTypes = {
    * Event triggered when global filter field has changed
    */
   onGlobalFilterChange: PropTypes.func,
+  /**
+   * Event triggered when a row is clicked
+   */
+  onRowClick: PropTypes.func,
   /**
    * Pages
    */

--- a/package/src/components/DataTable/DataTable.md
+++ b/package/src/components/DataTable/DataTable.md
@@ -76,9 +76,15 @@ function TableExample() {
     console.log("Selected rows", selectedRows);
   }, []);
 
+  // Row click callback
+  const onRowClick = useCallback(async ({ row }) => {
+    console.log("Row clicked", row);
+  }, []);
+
   const dataTableProps = useDataTable({
     columns,
     onFetchData,
+    onRowClick,
     onSelectRows,
     getRowID: (row, index) => row.id
   });
@@ -301,6 +307,18 @@ function TableExample() {
     // to the `useDataTable` hook.
     {
       id: "selection",
+      headerProps: {},
+      cellProps: {
+        // Disables the cell click if the row is clickable
+        // This is important if you have a callback for onRowClick, as the checkbox cell
+        // will also trigger the row click.
+        // Alternatively you can control the onClick with the following option
+        // onClick: (event) => event.stopPropagation(),
+        isClickDisabled: true,
+
+        // All other props will be applied to the table cell.
+        padding: "checkbox",
+      },
       // The header can use the table's getToggleAllRowsSelectedProps method
       // to render a checkbox
       // eslint-disable-next-line react/no-multi-comp,react/display-name,react/prop-types
@@ -320,6 +338,15 @@ function TableExample() {
     {
       Header: "Name",
       accessor: "fullName",
+      cellProps: (cell) => {
+        // Call props can also be a function, in case you want to
+        // dynamically create props
+        return {
+          style: {
+            cursor: "pointer"
+          }
+        }
+      },
       Cell: ({ row }) => (
         <Link href={`#/Components/Content/DataTable/${row.values.fullName}`}>
           {row.values.fullName}
@@ -399,9 +426,15 @@ function TableExample() {
     console.log("Selected rows", selectedRows);
   }, []);
 
+  // Row click callback
+  const onRowClick = useCallback(async ({ row }) => {
+    console.log("Row clicked", row);
+  }, []);
+
   const dataTableProps = useDataTable({
     columns,
     onFetchData,
+    onRowClick,
     onSelectRows,
     getRowID: (row, index) => row.id
   });

--- a/package/src/components/DataTable/__snapshots__/DataTable.test.js.snap
+++ b/package/src/components/DataTable/__snapshots__/DataTable.test.js.snap
@@ -38,7 +38,7 @@ exports[`basic snapshot - only default props 1`] = `
       class="MuiTableBody-root makeStyles-tableBody-2"
     >
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-7 makeStyles-tableRowOdd-3"
+        class="MuiTableRow-root makeStyles-tableRowHover-8 makeStyles-tableRowOdd-3"
       >
         <td
           class="MuiTableCell-root makeStyles-tableCell-5 MuiTableCell-body"
@@ -57,7 +57,7 @@ exports[`basic snapshot - only default props 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-7"
+        class="MuiTableRow-root makeStyles-tableRowHover-8"
       >
         <td
           class="MuiTableCell-root makeStyles-tableCell-5 MuiTableCell-body"
@@ -76,7 +76,7 @@ exports[`basic snapshot - only default props 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-7 makeStyles-tableRowOdd-3"
+        class="MuiTableRow-root makeStyles-tableRowHover-8 makeStyles-tableRowOdd-3"
       >
         <td
           class="MuiTableCell-root makeStyles-tableCell-5 MuiTableCell-body"
@@ -95,7 +95,7 @@ exports[`basic snapshot - only default props 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-7"
+        class="MuiTableRow-root makeStyles-tableRowHover-8"
       >
         <td
           class="MuiTableCell-root makeStyles-tableCell-5 MuiTableCell-body"
@@ -114,7 +114,7 @@ exports[`basic snapshot - only default props 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-7 makeStyles-tableRowOdd-3"
+        class="MuiTableRow-root makeStyles-tableRowHover-8 makeStyles-tableRowOdd-3"
       >
         <td
           class="MuiTableCell-root makeStyles-tableCell-5 MuiTableCell-body"
@@ -133,7 +133,7 @@ exports[`basic snapshot - only default props 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-7"
+        class="MuiTableRow-root makeStyles-tableRowHover-8"
       >
         <td
           class="MuiTableCell-root makeStyles-tableCell-5 MuiTableCell-body"
@@ -152,7 +152,7 @@ exports[`basic snapshot - only default props 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-7 makeStyles-tableRowOdd-3"
+        class="MuiTableRow-root makeStyles-tableRowHover-8 makeStyles-tableRowOdd-3"
       >
         <td
           class="MuiTableCell-root makeStyles-tableCell-5 MuiTableCell-body"
@@ -171,7 +171,7 @@ exports[`basic snapshot - only default props 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-7"
+        class="MuiTableRow-root makeStyles-tableRowHover-8"
       >
         <td
           class="MuiTableCell-root makeStyles-tableCell-5 MuiTableCell-body"
@@ -190,7 +190,7 @@ exports[`basic snapshot - only default props 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-7 makeStyles-tableRowOdd-3"
+        class="MuiTableRow-root makeStyles-tableRowHover-8 makeStyles-tableRowOdd-3"
       >
         <td
           class="MuiTableCell-root makeStyles-tableCell-5 MuiTableCell-body"
@@ -209,7 +209,7 @@ exports[`basic snapshot - only default props 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-7"
+        class="MuiTableRow-root makeStyles-tableRowHover-8"
       >
         <td
           class="MuiTableCell-root makeStyles-tableCell-5 MuiTableCell-body"
@@ -233,7 +233,7 @@ exports[`basic snapshot - only default props 1`] = `
     class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
   >
     <div
-      class="MuiBox-root MuiBox-root-33"
+      class="MuiBox-root MuiBox-root-34"
     >
       <span
         class="MuiTypography-root MuiTypography-body2"
@@ -241,7 +241,7 @@ exports[`basic snapshot - only default props 1`] = `
         Page
       </span>
       <div
-        class="MuiBox-root MuiBox-root-64"
+        class="MuiBox-root MuiBox-root-65"
       >
         <div
           class="MuiFormControl-root MuiTextField-root makeStyles-textField-6 MuiFormControl-marginDense"
@@ -259,11 +259,11 @@ exports[`basic snapshot - only default props 1`] = `
             />
             <fieldset
               aria-hidden="true"
-              class="PrivateNotchedOutline-root-103 MuiOutlinedInput-notchedOutline"
+              class="PrivateNotchedOutline-root-104 MuiOutlinedInput-notchedOutline"
               style="padding-left: 8px;"
             >
               <legend
-                class="PrivateNotchedOutline-legend-104"
+                class="PrivateNotchedOutline-legend-105"
                 style="width: 0px;"
               >
                 <span>
@@ -281,10 +281,10 @@ exports[`basic snapshot - only default props 1`] = `
       </span>
     </div>
     <div
-      class="MuiBox-root MuiBox-root-105"
+      class="MuiBox-root MuiBox-root-106"
     >
       <div
-        class="makeStyles-root-106"
+        class="makeStyles-root-107"
       >
         <div
           class=" css-2b097c-container"
@@ -297,11 +297,11 @@ exports[`basic snapshot - only default props 1`] = `
             >
               <div
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-107"
+                class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-108"
                 type="text"
               >
                 <div
-                  class="makeStyles-valueContainer-108"
+                  class="makeStyles-valueContainer-109"
                 >
                   <div
                     class=" css-cs1jeq-singleValue"
@@ -360,11 +360,11 @@ exports[`basic snapshot - only default props 1`] = `
               </div>
               <fieldset
                 aria-hidden="true"
-                class="PrivateNotchedOutline-root-103 MuiOutlinedInput-notchedOutline"
+                class="PrivateNotchedOutline-root-104 MuiOutlinedInput-notchedOutline"
                 style="padding-left: 8px;"
               >
                 <legend
-                  class="PrivateNotchedOutline-legend-104"
+                  class="PrivateNotchedOutline-legend-105"
                   style="width: 0px;"
                 >
                   <span>
@@ -378,7 +378,7 @@ exports[`basic snapshot - only default props 1`] = `
       </div>
     </div>
     <div
-      class="MuiBox-root MuiBox-root-115"
+      class="MuiBox-root MuiBox-root-116"
     />
     <button
       class="MuiButtonBase-root MuiButton-root MuiButton-text Mui-disabled Mui-disabled"
@@ -443,27 +443,27 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
     class="MuiTable-root"
   >
     <thead
-      class="MuiTableHead-root makeStyles-tableHead-475"
+      class="MuiTableHead-root makeStyles-tableHead-478"
     >
       <tr
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root makeStyles-tableHead-475 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-478 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root makeStyles-tableHead-475 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-478 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
           Email
         </th>
         <th
-          class="MuiTableCell-root makeStyles-tableHead-475 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-478 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
@@ -472,23 +472,23 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
       </tr>
     </thead>
     <tbody
-      class="MuiTableBody-root makeStyles-tableBody-473"
+      class="MuiTableBody-root makeStyles-tableBody-476"
     >
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-478 makeStyles-tableRowOdd-474"
+        class="MuiTableRow-root makeStyles-tableRowHover-482 makeStyles-tableRowOdd-477"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           Kennett Fenlon
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           kfenlona@skyrock.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           <span>
             <svg
@@ -507,20 +507,20 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-478"
+        class="MuiTableRow-root makeStyles-tableRowHover-482"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           Gonzales Winsley
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           gwinsleyb@oakley.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           <span>
             <svg
@@ -539,20 +539,20 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-478 makeStyles-tableRowOdd-474"
+        class="MuiTableRow-root makeStyles-tableRowHover-482 makeStyles-tableRowOdd-477"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           Eleonora McKean
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           emckeanc@hhs.gov
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           <span>
             <svg
@@ -571,20 +571,20 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-478"
+        class="MuiTableRow-root makeStyles-tableRowHover-482"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           Verena MacGuiness
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           vmacguinessd@github.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           <span>
             <svg
@@ -603,20 +603,20 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-478 makeStyles-tableRowOdd-474"
+        class="MuiTableRow-root makeStyles-tableRowHover-482 makeStyles-tableRowOdd-477"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           Nikkie Kigelman
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           nkigelmane@ucla.edu
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           <span>
             <svg
@@ -635,20 +635,20 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-478"
+        class="MuiTableRow-root makeStyles-tableRowHover-482"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           Jard Meys
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           jmeysf@jigsy.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           <span>
             <svg
@@ -667,20 +667,20 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-478 makeStyles-tableRowOdd-474"
+        class="MuiTableRow-root makeStyles-tableRowHover-482 makeStyles-tableRowOdd-477"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           Noland Vaen
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           nvaeng@wikipedia.org
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           <span>
             <svg
@@ -699,20 +699,20 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-478"
+        class="MuiTableRow-root makeStyles-tableRowHover-482"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           Xylina Neely
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           xneelyh@list-manage.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           <span>
             <svg
@@ -731,20 +731,20 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-478 makeStyles-tableRowOdd-474"
+        class="MuiTableRow-root makeStyles-tableRowHover-482 makeStyles-tableRowOdd-477"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           Amandie Jaegar
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           ajaegari@liveinternet.ru
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           <span>
             <svg
@@ -763,20 +763,20 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-478"
+        class="MuiTableRow-root makeStyles-tableRowHover-482"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           Hillard Kenderdine
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           hkenderdinej@cornell.edu
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-476 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-479 MuiTableCell-body"
         >
           <span>
             <svg
@@ -800,7 +800,7 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
     class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
   >
     <div
-      class="MuiBox-root MuiBox-root-513"
+      class="MuiBox-root MuiBox-root-517"
     >
       <span
         class="MuiTypography-root MuiTypography-body2"
@@ -808,10 +808,10 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
         Page
       </span>
       <div
-        class="MuiBox-root MuiBox-root-544"
+        class="MuiBox-root MuiBox-root-548"
       >
         <div
-          class="MuiFormControl-root MuiTextField-root makeStyles-textField-477 MuiFormControl-marginDense"
+          class="MuiFormControl-root MuiTextField-root makeStyles-textField-480 MuiFormControl-marginDense"
           max="10"
           min="1"
         >
@@ -826,11 +826,11 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
             />
             <fieldset
               aria-hidden="true"
-              class="PrivateNotchedOutline-root-583 MuiOutlinedInput-notchedOutline"
+              class="PrivateNotchedOutline-root-587 MuiOutlinedInput-notchedOutline"
               style="padding-left: 8px;"
             >
               <legend
-                class="PrivateNotchedOutline-legend-584"
+                class="PrivateNotchedOutline-legend-588"
                 style="width: 0px;"
               >
                 <span>
@@ -848,10 +848,10 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
       </span>
     </div>
     <div
-      class="MuiBox-root MuiBox-root-585"
+      class="MuiBox-root MuiBox-root-589"
     >
       <div
-        class="makeStyles-root-586"
+        class="makeStyles-root-590"
       >
         <div
           class=" css-2b097c-container"
@@ -864,11 +864,11 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
             >
               <div
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-587"
+                class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-591"
                 type="text"
               >
                 <div
-                  class="makeStyles-valueContainer-588"
+                  class="makeStyles-valueContainer-592"
                 >
                   <div
                     class=" css-cs1jeq-singleValue"
@@ -927,11 +927,11 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
               </div>
               <fieldset
                 aria-hidden="true"
-                class="PrivateNotchedOutline-root-583 MuiOutlinedInput-notchedOutline"
+                class="PrivateNotchedOutline-root-587 MuiOutlinedInput-notchedOutline"
                 style="padding-left: 8px;"
               >
                 <legend
-                  class="PrivateNotchedOutline-legend-584"
+                  class="PrivateNotchedOutline-legend-588"
                   style="width: 0px;"
                 >
                   <span>
@@ -945,7 +945,7 @@ exports[`client-side paginated snapshot - advances one page forward 1`] = `
       </div>
     </div>
     <div
-      class="MuiBox-root MuiBox-root-595"
+      class="MuiBox-root MuiBox-root-599"
     />
     <button
       class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1012,27 +1012,27 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
     class="MuiTable-root"
   >
     <thead
-      class="MuiTableHead-root makeStyles-tableHead-632"
+      class="MuiTableHead-root makeStyles-tableHead-636"
     >
       <tr
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root makeStyles-tableHead-632 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-636 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root makeStyles-tableHead-632 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-636 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
           Email
         </th>
         <th
-          class="MuiTableCell-root makeStyles-tableHead-632 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-636 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
@@ -1041,23 +1041,23 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
       </tr>
     </thead>
     <tbody
-      class="MuiTableBody-root makeStyles-tableBody-630"
+      class="MuiTableBody-root makeStyles-tableBody-634"
     >
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-635 makeStyles-tableRowOdd-631"
+        class="MuiTableRow-root makeStyles-tableRowHover-640 makeStyles-tableRowOdd-635"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           Claudia Whitmarsh
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           cwhitmarsh0@va.gov
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1076,20 +1076,20 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-635"
+        class="MuiTableRow-root makeStyles-tableRowHover-640"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           Ringo Coalbran
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           rcoalbran1@paginegialle.it
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1108,20 +1108,20 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-635 makeStyles-tableRowOdd-631"
+        class="MuiTableRow-root makeStyles-tableRowHover-640 makeStyles-tableRowOdd-635"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           Augusta Colman
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           acolman2@amazonaws.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1140,20 +1140,20 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-635"
+        class="MuiTableRow-root makeStyles-tableRowHover-640"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           Trisha Copcote
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           tcopcote3@163.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1172,20 +1172,20 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-635 makeStyles-tableRowOdd-631"
+        class="MuiTableRow-root makeStyles-tableRowHover-640 makeStyles-tableRowOdd-635"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           Quill Ionnidis
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           qionnidis4@dagondesign.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1204,20 +1204,20 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-635"
+        class="MuiTableRow-root makeStyles-tableRowHover-640"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           Berny Sisneros
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           bsisneros5@domainmarket.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1236,20 +1236,20 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-635 makeStyles-tableRowOdd-631"
+        class="MuiTableRow-root makeStyles-tableRowHover-640 makeStyles-tableRowOdd-635"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           Ambrosi Thorrington
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           athorrington6@google.co.jp
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1268,20 +1268,20 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-635"
+        class="MuiTableRow-root makeStyles-tableRowHover-640"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           Gustavus Swanton
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           gswanton7@wikispaces.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1300,20 +1300,20 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-635 makeStyles-tableRowOdd-631"
+        class="MuiTableRow-root makeStyles-tableRowHover-640 makeStyles-tableRowOdd-635"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           Germain Dunk
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           gdunk8@businessinsider.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1332,20 +1332,20 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-635"
+        class="MuiTableRow-root makeStyles-tableRowHover-640"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           Korney Goodall
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           kgoodall9@phpbb.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-633 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-637 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1369,7 +1369,7 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
     class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
   >
     <div
-      class="MuiBox-root MuiBox-root-670"
+      class="MuiBox-root MuiBox-root-675"
     >
       <span
         class="MuiTypography-root MuiTypography-body2"
@@ -1377,10 +1377,10 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
         Page
       </span>
       <div
-        class="MuiBox-root MuiBox-root-701"
+        class="MuiBox-root MuiBox-root-706"
       >
         <div
-          class="MuiFormControl-root MuiTextField-root makeStyles-textField-634 MuiFormControl-marginDense"
+          class="MuiFormControl-root MuiTextField-root makeStyles-textField-638 MuiFormControl-marginDense"
           max="10"
           min="1"
         >
@@ -1395,11 +1395,11 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
             />
             <fieldset
               aria-hidden="true"
-              class="PrivateNotchedOutline-root-740 MuiOutlinedInput-notchedOutline"
+              class="PrivateNotchedOutline-root-745 MuiOutlinedInput-notchedOutline"
               style="padding-left: 8px;"
             >
               <legend
-                class="PrivateNotchedOutline-legend-741"
+                class="PrivateNotchedOutline-legend-746"
                 style="width: 0px;"
               >
                 <span>
@@ -1417,10 +1417,10 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
       </span>
     </div>
     <div
-      class="MuiBox-root MuiBox-root-742"
+      class="MuiBox-root MuiBox-root-747"
     >
       <div
-        class="makeStyles-root-743"
+        class="makeStyles-root-748"
       >
         <div
           class=" css-2b097c-container"
@@ -1433,11 +1433,11 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
             >
               <div
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-744"
+                class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-749"
                 type="text"
               >
                 <div
-                  class="makeStyles-valueContainer-745"
+                  class="makeStyles-valueContainer-750"
                 >
                   <div
                     class=" css-cs1jeq-singleValue"
@@ -1496,11 +1496,11 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
               </div>
               <fieldset
                 aria-hidden="true"
-                class="PrivateNotchedOutline-root-740 MuiOutlinedInput-notchedOutline"
+                class="PrivateNotchedOutline-root-745 MuiOutlinedInput-notchedOutline"
                 style="padding-left: 8px;"
               >
                 <legend
-                  class="PrivateNotchedOutline-legend-741"
+                  class="PrivateNotchedOutline-legend-746"
                   style="width: 0px;"
                 >
                   <span>
@@ -1514,7 +1514,7 @@ exports[`client-side paginated snapshot - advances one page forward and back to 
       </div>
     </div>
     <div
-      class="MuiBox-root MuiBox-root-752"
+      class="MuiBox-root MuiBox-root-757"
     />
     <button
       class="MuiButtonBase-root MuiButton-root MuiButton-text Mui-disabled Mui-disabled"
@@ -1579,27 +1579,27 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
     class="MuiTable-root"
   >
     <thead
-      class="MuiTableHead-root makeStyles-tableHead-161"
+      class="MuiTableHead-root makeStyles-tableHead-162"
     >
       <tr
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root makeStyles-tableHead-161 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-162 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root makeStyles-tableHead-161 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-162 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
           Email
         </th>
         <th
-          class="MuiTableCell-root makeStyles-tableHead-161 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-162 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
@@ -1608,23 +1608,23 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
       </tr>
     </thead>
     <tbody
-      class="MuiTableBody-root makeStyles-tableBody-159"
+      class="MuiTableBody-root makeStyles-tableBody-160"
     >
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-164 makeStyles-tableRowOdd-160"
+        class="MuiTableRow-root makeStyles-tableRowHover-166 makeStyles-tableRowOdd-161"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           Kennett Fenlon
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           kfenlona@skyrock.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1643,20 +1643,20 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-164"
+        class="MuiTableRow-root makeStyles-tableRowHover-166"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           Gonzales Winsley
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           gwinsleyb@oakley.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1675,20 +1675,20 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-164 makeStyles-tableRowOdd-160"
+        class="MuiTableRow-root makeStyles-tableRowHover-166 makeStyles-tableRowOdd-161"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           Eleonora McKean
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           emckeanc@hhs.gov
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1707,20 +1707,20 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-164"
+        class="MuiTableRow-root makeStyles-tableRowHover-166"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           Verena MacGuiness
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           vmacguinessd@github.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1739,20 +1739,20 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-164 makeStyles-tableRowOdd-160"
+        class="MuiTableRow-root makeStyles-tableRowHover-166 makeStyles-tableRowOdd-161"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           Nikkie Kigelman
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           nkigelmane@ucla.edu
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1771,20 +1771,20 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-164"
+        class="MuiTableRow-root makeStyles-tableRowHover-166"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           Jard Meys
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           jmeysf@jigsy.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1803,20 +1803,20 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-164 makeStyles-tableRowOdd-160"
+        class="MuiTableRow-root makeStyles-tableRowHover-166 makeStyles-tableRowOdd-161"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           Noland Vaen
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           nvaeng@wikipedia.org
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1835,20 +1835,20 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-164"
+        class="MuiTableRow-root makeStyles-tableRowHover-166"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           Xylina Neely
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           xneelyh@list-manage.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1867,20 +1867,20 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-164 makeStyles-tableRowOdd-160"
+        class="MuiTableRow-root makeStyles-tableRowHover-166 makeStyles-tableRowOdd-161"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           Amandie Jaegar
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           ajaegari@liveinternet.ru
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1899,20 +1899,20 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-164"
+        class="MuiTableRow-root makeStyles-tableRowHover-166"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           Hillard Kenderdine
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           hkenderdinej@cornell.edu
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-162 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-163 MuiTableCell-body"
         >
           <span>
             <svg
@@ -1936,7 +1936,7 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
     class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
   >
     <div
-      class="MuiBox-root MuiBox-root-190"
+      class="MuiBox-root MuiBox-root-192"
     >
       <span
         class="MuiTypography-root MuiTypography-body2"
@@ -1944,10 +1944,10 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
         Page
       </span>
       <div
-        class="MuiBox-root MuiBox-root-221"
+        class="MuiBox-root MuiBox-root-223"
       >
         <div
-          class="MuiFormControl-root MuiTextField-root makeStyles-textField-163 MuiFormControl-marginDense"
+          class="MuiFormControl-root MuiTextField-root makeStyles-textField-164 MuiFormControl-marginDense"
           max="10"
           min="1"
         >
@@ -1962,11 +1962,11 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
             />
             <fieldset
               aria-hidden="true"
-              class="PrivateNotchedOutline-root-260 MuiOutlinedInput-notchedOutline"
+              class="PrivateNotchedOutline-root-262 MuiOutlinedInput-notchedOutline"
               style="padding-left: 8px;"
             >
               <legend
-                class="PrivateNotchedOutline-legend-261"
+                class="PrivateNotchedOutline-legend-263"
                 style="width: 0px;"
               >
                 <span>
@@ -1984,10 +1984,10 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
       </span>
     </div>
     <div
-      class="MuiBox-root MuiBox-root-262"
+      class="MuiBox-root MuiBox-root-264"
     >
       <div
-        class="makeStyles-root-263"
+        class="makeStyles-root-265"
       >
         <div
           class=" css-2b097c-container"
@@ -2000,11 +2000,11 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
             >
               <div
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-264"
+                class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-266"
                 type="text"
               >
                 <div
-                  class="makeStyles-valueContainer-265"
+                  class="makeStyles-valueContainer-267"
                 >
                   <div
                     class=" css-cs1jeq-singleValue"
@@ -2063,11 +2063,11 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
               </div>
               <fieldset
                 aria-hidden="true"
-                class="PrivateNotchedOutline-root-260 MuiOutlinedInput-notchedOutline"
+                class="PrivateNotchedOutline-root-262 MuiOutlinedInput-notchedOutline"
                 style="padding-left: 8px;"
               >
                 <legend
-                  class="PrivateNotchedOutline-legend-261"
+                  class="PrivateNotchedOutline-legend-263"
                   style="width: 0px;"
                 >
                   <span>
@@ -2081,7 +2081,7 @@ exports[`server-side paginated snapshot - advances one page forward 1`] = `
       </div>
     </div>
     <div
-      class="MuiBox-root MuiBox-root-272"
+      class="MuiBox-root MuiBox-root-274"
     />
     <button
       class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2148,27 +2148,27 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
     class="MuiTable-root"
   >
     <thead
-      class="MuiTableHead-root makeStyles-tableHead-318"
+      class="MuiTableHead-root makeStyles-tableHead-320"
     >
       <tr
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root makeStyles-tableHead-318 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-320 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root makeStyles-tableHead-318 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-320 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
           Email
         </th>
         <th
-          class="MuiTableCell-root makeStyles-tableHead-318 MuiTableCell-head"
+          class="MuiTableCell-root makeStyles-tableHead-320 MuiTableCell-head"
           colspan="1"
           scope="col"
         >
@@ -2177,23 +2177,23 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
       </tr>
     </thead>
     <tbody
-      class="MuiTableBody-root makeStyles-tableBody-316"
+      class="MuiTableBody-root makeStyles-tableBody-318"
     >
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-321 makeStyles-tableRowOdd-317"
+        class="MuiTableRow-root makeStyles-tableRowHover-324 makeStyles-tableRowOdd-319"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           Claudia Whitmarsh
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           cwhitmarsh0@va.gov
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           <span>
             <svg
@@ -2212,20 +2212,20 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-321"
+        class="MuiTableRow-root makeStyles-tableRowHover-324"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           Ringo Coalbran
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           rcoalbran1@paginegialle.it
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           <span>
             <svg
@@ -2244,20 +2244,20 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-321 makeStyles-tableRowOdd-317"
+        class="MuiTableRow-root makeStyles-tableRowHover-324 makeStyles-tableRowOdd-319"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           Augusta Colman
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           acolman2@amazonaws.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           <span>
             <svg
@@ -2276,20 +2276,20 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-321"
+        class="MuiTableRow-root makeStyles-tableRowHover-324"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           Trisha Copcote
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           tcopcote3@163.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           <span>
             <svg
@@ -2308,20 +2308,20 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-321 makeStyles-tableRowOdd-317"
+        class="MuiTableRow-root makeStyles-tableRowHover-324 makeStyles-tableRowOdd-319"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           Quill Ionnidis
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           qionnidis4@dagondesign.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           <span>
             <svg
@@ -2340,20 +2340,20 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-321"
+        class="MuiTableRow-root makeStyles-tableRowHover-324"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           Berny Sisneros
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           bsisneros5@domainmarket.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           <span>
             <svg
@@ -2372,20 +2372,20 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-321 makeStyles-tableRowOdd-317"
+        class="MuiTableRow-root makeStyles-tableRowHover-324 makeStyles-tableRowOdd-319"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           Ambrosi Thorrington
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           athorrington6@google.co.jp
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           <span>
             <svg
@@ -2404,20 +2404,20 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-321"
+        class="MuiTableRow-root makeStyles-tableRowHover-324"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           Gustavus Swanton
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           gswanton7@wikispaces.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           <span>
             <svg
@@ -2436,20 +2436,20 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-321 makeStyles-tableRowOdd-317"
+        class="MuiTableRow-root makeStyles-tableRowHover-324 makeStyles-tableRowOdd-319"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           Germain Dunk
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           gdunk8@businessinsider.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           <span>
             <svg
@@ -2468,20 +2468,20 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
         </td>
       </tr>
       <tr
-        class="MuiTableRow-root makeStyles-tableRowHover-321"
+        class="MuiTableRow-root makeStyles-tableRowHover-324"
       >
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           Korney Goodall
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           kgoodall9@phpbb.com
         </td>
         <td
-          class="MuiTableCell-root makeStyles-tableCell-319 MuiTableCell-body"
+          class="MuiTableCell-root makeStyles-tableCell-321 MuiTableCell-body"
         >
           <span>
             <svg
@@ -2505,7 +2505,7 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
     class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
   >
     <div
-      class="MuiBox-root MuiBox-root-347"
+      class="MuiBox-root MuiBox-root-350"
     >
       <span
         class="MuiTypography-root MuiTypography-body2"
@@ -2513,10 +2513,10 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
         Page
       </span>
       <div
-        class="MuiBox-root MuiBox-root-378"
+        class="MuiBox-root MuiBox-root-381"
       >
         <div
-          class="MuiFormControl-root MuiTextField-root makeStyles-textField-320 MuiFormControl-marginDense"
+          class="MuiFormControl-root MuiTextField-root makeStyles-textField-322 MuiFormControl-marginDense"
           max="10"
           min="1"
         >
@@ -2531,11 +2531,11 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
             />
             <fieldset
               aria-hidden="true"
-              class="PrivateNotchedOutline-root-417 MuiOutlinedInput-notchedOutline"
+              class="PrivateNotchedOutline-root-420 MuiOutlinedInput-notchedOutline"
               style="padding-left: 8px;"
             >
               <legend
-                class="PrivateNotchedOutline-legend-418"
+                class="PrivateNotchedOutline-legend-421"
                 style="width: 0px;"
               >
                 <span>
@@ -2553,10 +2553,10 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
       </span>
     </div>
     <div
-      class="MuiBox-root MuiBox-root-419"
+      class="MuiBox-root MuiBox-root-422"
     >
       <div
-        class="makeStyles-root-420"
+        class="makeStyles-root-423"
       >
         <div
           class=" css-2b097c-container"
@@ -2569,11 +2569,11 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
             >
               <div
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-421"
+                class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-424"
                 type="text"
               >
                 <div
-                  class="makeStyles-valueContainer-422"
+                  class="makeStyles-valueContainer-425"
                 >
                   <div
                     class=" css-cs1jeq-singleValue"
@@ -2632,11 +2632,11 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
               </div>
               <fieldset
                 aria-hidden="true"
-                class="PrivateNotchedOutline-root-417 MuiOutlinedInput-notchedOutline"
+                class="PrivateNotchedOutline-root-420 MuiOutlinedInput-notchedOutline"
                 style="padding-left: 8px;"
               >
                 <legend
-                  class="PrivateNotchedOutline-legend-418"
+                  class="PrivateNotchedOutline-legend-421"
                   style="width: 0px;"
                 >
                   <span>
@@ -2650,7 +2650,7 @@ exports[`server-side paginated snapshot - advances one page forward and back to 
       </div>
     </div>
     <div
-      class="MuiBox-root MuiBox-root-429"
+      class="MuiBox-root MuiBox-root-432"
     />
     <button
       class="MuiButtonBase-root MuiButton-root MuiButton-text Mui-disabled Mui-disabled"

--- a/package/src/components/DataTable/helpers/useDataTable.js
+++ b/package/src/components/DataTable/helpers/useDataTable.js
@@ -7,6 +7,7 @@ import {
   usePagination,
   useRowSelect
 } from "react-table";
+import useDataTableCellProps from "./useDataTableCellProps";
 
 /**
  * useDataTable
@@ -18,6 +19,7 @@ export default function useDataTable({
   columns,
   onFetchData,
   onSelectRows,
+  onRowClick,
   onGlobalFilterChange,
   pageSize: defaultPageSize = 10,
   ...otherProps
@@ -30,6 +32,7 @@ export default function useDataTable({
 
   const isServerControlled = typeof onFetchData === "function";
   const isSelectable = typeof onSelectRows === "function";
+  const isRowInteractive = typeof onRowClick === "function";
   let data = stateData;
 
   if (Array.isArray(simpleData)) {
@@ -44,6 +47,11 @@ export default function useDataTable({
         return [
           {
             id: "selection",
+            cellProps: {
+              // Disable cell click so that clicking the checkbox doesn't also trigger the row click
+              isClickDisabled: true,
+              padding: "checkbox"
+            },
             // The header can use the table's getToggleAllRowsSelectedProps method
             // to render a checkbox
             // eslint-disable-next-line react/no-multi-comp,react/display-name,react/prop-types
@@ -123,6 +131,26 @@ export default function useDataTable({
     setGlobalFilter(event.target.value);
   }, [onGlobalFilterChange]);
 
+  const handleRowClick = useMemo(() => {
+    if (isRowInteractive) {
+      return (row) => () => {
+        onRowClick({
+          row,
+          data,
+          setData,
+          setPageCount,
+          sortBy,
+          filters,
+          pageIndex,
+          pageSize,
+          selectedRows
+        });
+      };
+    }
+
+    return null;
+  }, [onRowClick]);
+
   const dataTableProps = useTable(
     {
       columns: columnsWithCheckboxes,
@@ -137,12 +165,14 @@ export default function useDataTable({
     },
     useFilters,
     usePagination,
-    useRowSelect
+    useRowSelect,
+    useDataTableCellProps
   );
 
   return {
     ...dataTableProps,
     isSelectable,
-    onGlobalFilterChange: handleGlobalFilterChange
+    onGlobalFilterChange: handleGlobalFilterChange,
+    onRowClick: handleRowClick
   };
 }

--- a/package/src/components/DataTable/helpers/useDataTableCellProps.js
+++ b/package/src/components/DataTable/helpers/useDataTableCellProps.js
@@ -1,0 +1,61 @@
+import PropTypes from "prop-types";
+
+const propTypes = {
+  columns: PropTypes.arrayOf(PropTypes.shape({
+    cellProps: PropTypes.shape({
+      isClickDisabled: PropTypes.bool
+    })
+  }))
+};
+
+/**
+ * useMain
+ * @summary Hook used to add custom props to cells, and headers from the column definition
+ * @param {Object} instance React Table instance
+ * @returns {Object} React Table instance
+ */
+function useMain(instance) {
+  PropTypes.checkPropTypes(propTypes, instance, "property", "useDataTableCellProps");
+
+  const {
+    hooks: {
+      getHeaderProps,
+      getCellProps
+    }
+  } = instance;
+
+  // Add a helpers function to get additional headerProps from the column definition
+  getHeaderProps.push((header) => {
+    if (typeof header.headerProps === "function") {
+      return header.headerProps(header, instance);
+    }
+
+    return {
+      ...header.headerProps
+    };
+  });
+
+  // Add a helpers function to get additional cellProps from the column definition
+  getCellProps.push((cell) => {
+    if (typeof cell.column.cellProps === "function") {
+      return cell.column.cellProps(cell, instance);
+    }
+
+    return {
+      ...cell.column.cellProps
+    };
+  });
+
+  return instance;
+}
+
+/**
+ * useDataTableCellProps
+ * @param {Object} hooks Hooks object from react-table useTable
+ * @returns {undefined} no return
+ */
+export default function useDataTableCellProps(hooks) {
+  hooks.useMain.push(useMain);
+}
+
+useDataTableCellProps.pluginName = "useDataTableCellProps";


### PR DESCRIPTION
Resolves #117 
Impact: **minor**  
Type: **feature**

## Component

Adds a row click callback, as well as cell/header props to the `DataTable` Component and `useDataTable` hook;

## Screenshots

## Breaking changes

## Testing
1. Click the rows in the DataTable example and look and loot at the console.log messages

**First table and last table examples are with clickable rows.**
