### PR TITLE
docs(status): add DataTable, Toast

### DIFF
--- a/styleguide/src/sections/Status.md
+++ b/styleguide/src/sections/Status.md
@@ -7,7 +7,9 @@ Tracking the design, development and usage of new Catalyst components in Reactio
 | **Card**          | Themed by Catalyst | 1.9              | 2.3              |
 | **Chip**          | Catalyst           | 1.4              | 2.2              |
 | **ConfirmDialog** | Catalyst           | 1.2              | 2.1              |
+| **DataTable** | Catalyst           | 1.13              | future              |
 | **Select, MultiSelect**        | Catalyst           | 1.7              | 2.3              |
 | **SplitButton**   | Catalyst           | 1.5              | 2.2              |
 | **Tab**           | Themed by Catalyst | 1.9              | 2.3              |
+| **Toast**           | Catalyst | 1.14              | future              |
 | **Typography**    | Themed by Catalyst | 1.7              | 2.2              |


### PR DESCRIPTION
At the end of every cycle, I update the status page with the latest components:
<img width="713" alt="Screen Shot 2019-10-04 at 3 38 41 PM" src="https://user-images.githubusercontent.com/3673236/66244407-1c543980-e6bd-11e9-918c-2b3336e5c058.png">
