### PR TITLE
chore: change main branch to trunk

### DIFF
--- a/.circleci/bin/docker-tags
+++ b/.circleci/bin/docker-tags
@@ -26,7 +26,7 @@ git show-ref --tags -d | grep "^${SHA1}" | sed -e 's,.* refs/tags/,,' -e 's/\^{}
   echo "%"
 
 # Tag with latest if certain conditions are met
-if [[ "$BRANCH" == "master" ]]; then
+if [[ "$BRANCH" == "trunk" ]]; then
   # Check to see if we have a valid `vX.X.X` tag and assign to CURRENT_TAG
   CURRENT_TAG=$( \
     git show-ref --tags -d \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,4 +209,4 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only: trunk

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 Resolves #issueNumber
-Impact: **breaking|critical|major|minor**  
+Impact: **breaking|critical|major|minor**
 Type: **feature|bugfix|performance|test|style|refactor|docs|chore**
 
 <!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->
@@ -22,4 +22,4 @@ You should almost never include "BREAKING CHANGES" because we’re duplicating c
 2. Assume that testers already know how to start the app, and do the basic setup tasks.
 3. Be detailed enough that someone can work through it without being too granular
 
-More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
+More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/trunk/contributing-to-reaction)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,7 +10,7 @@ This isn’t an exhaustive list of things that you can’t do. Rather, take it i
 
 This code of conduct applies to all spaces managed by Reaction Commerce. This includes our [development chat room](https://gitter.im/reactioncommerce/reaction), [forums](https://forums.reactioncommerce.com), [blog](https://blog.reactioncommerce.com), mailing lists, [issue tracker](https://github.com/reactioncommerce/reaction/issues), [project boards](https://github.com/reactioncommerce/reaction/projects), Reaction events and meetups, and any other forums or service created by the core project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
-If you believe someone is violating the code of conduct, we ask that you report it by emailing <mailto:conduct@reactioncommerce.com>. For more details, please see our [Reporting Guidelines](https://docs.reactioncommerce.com/reaction-docs/master/reporting-guide).
+If you believe someone is violating the code of conduct, we ask that you report it by emailing <mailto:conduct@reactioncommerce.com>. For more details, please see our [Reporting Guidelines](https://docs.reactioncommerce.com/reaction-docs/trunk/reporting-guide).
 
 -   **Be friendly and patient.**
 
@@ -35,4 +35,4 @@ If you believe someone is violating the code of conduct, we ask that you report 
 
 ## Questions?
 
-If you have questions, please see the [FAQs](https://docs.reactioncommerce.com/reaction-docs/master/guideline-faqs). If that doesn't answer your questions, feel free to [contact us](mailto:hello@reactioncommerce.com).
+If you have questions, please see the [FAQs](https://docs.reactioncommerce.com/reaction-docs/trunk/guideline-faqs). If that doesn't answer your questions, feel free to [contact us](mailto:hello@reactioncommerce.com).

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 This is a single project with a package of commerce-focused React UI components and the code for the Catalyst website:
 
-- [`@reactioncommerce/catalyst`](https://www.npmjs.com/package/@reactioncommerce/catalyst): See the [package.json](https://github.com/reactioncommerce/catalyst/blob/master/package/package.json) in [`/package`](https://github.com/reactioncommerce/catalyst/tree/master/package) folder.
-- [Catalyst Components](https://catalyst.reactioncommerce.com/): See the root [package.json](https://github.com/reactioncommerce/catalyst/blob/master/package.json).
+- [`@reactioncommerce/catalyst`](https://www.npmjs.com/package/@reactioncommerce/catalyst): See the [package.json](https://github.com/reactioncommerce/catalyst/blob/trunk/package/package.json) in [`/package`](https://github.com/reactioncommerce/catalyst/tree/trunk/package) folder.
+- [Catalyst Components](https://catalyst.reactioncommerce.com/): See the root [package.json](https://github.com/reactioncommerce/catalyst/blob/trunk/package.json).
 
 We use the [React Styleguidist](https://react-styleguidist.js.org/) package to run and build the Catalyst website, and running the style guide locally doubles as an interactive playground for developing and testing the components.
 

--- a/docs/creating-new-component.md
+++ b/docs/creating-new-component.md
@@ -48,7 +48,7 @@ This will be documented better in the future. For now, refer to existing compone
 
 Every component and utility function in this style guide must have a corresponding file containing component tests. All tests are written using, and run by, the [Jest](https://facebook.github.io/jest/) test framework, which is based on the Jasmine framework. If you haven't used Jest, you should read their documentation to get familiar.
 
-Review and follow all guidelines in [Writing Jest Unit Tests](https://docs.reactioncommerce.com/reaction-docs/master/writing-jest-unit-tests)
+Review and follow all guidelines in [Writing Jest Unit Tests](https://docs.reactioncommerce.com/reaction-docs/trunk/writing-jest-unit-tests)
 
 ## Write the component code
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -101,11 +101,11 @@ For this project specifically:
 
 ## Catalyst Package Publication
 
-The `@reactioncommerce/catalyst` package is automatically published by CI when commits are merged or pushed to the `master` branch. This is done using [semantic-release](https://www.npmjs.com/package/semantic-release), which also determines version bumps based on conventional Git commit messages.
+The `@reactioncommerce/catalyst` package is automatically published by CI when commits are merged or pushed to the `trunk` branch. This is done using [semantic-release](https://www.npmjs.com/package/semantic-release), which also determines version bumps based on conventional Git commit messages.
 
 ## Style Guide Publication
 
-The site is built by [`react-styleguidist`](https://github.com/styleguidist/react-styleguidist) and automatically published by CI and Netlify when commits are pushed to pull requests and the `master` branch.
+The site is built by [`react-styleguidist`](https://github.com/styleguidist/react-styleguidist) and automatically published by CI and Netlify when commits are pushed to pull requests and the `trunk` branch.
 
 Test the build locally by running `docker-compose run --rm web yarn run styleguide:build` and opening `styleguide/dist/index.html` in your browser.
 


### PR DESCRIPTION
update catalyst to make `trunk` the main branch, and update any relevant documentation inside this project.