### PR TITLE
feat: Add TextField component

### DIFF
--- a/package/src/components/TextField/TextField.js
+++ b/package/src/components/TextField/TextField.js
@@ -44,7 +44,7 @@ const useInputStyles = makeStyles((theme) => ({
     "padding": 0,
     "backgroundColor": theme.palette.colors.black02,
     "&$marginDense": {
-      paddingTop: 0
+      padding: 0
     }
   },
   /* Styles applied to the `NotchedOutline` element. */

--- a/package/src/components/TextField/TextField.js
+++ b/package/src/components/TextField/TextField.js
@@ -69,8 +69,6 @@ const useInputLabelStyles = makeStyles((theme) => ({
     position: "static",
     left: 0,
     top: 0,
-    // slight alteration to spec spacing to match visual spec result
-    // transform: 'translate(0, 24px) scale(1)',
     transform: "none"
   },
   shrink: {

--- a/package/src/components/TextField/TextField.js
+++ b/package/src/components/TextField/TextField.js
@@ -1,0 +1,292 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  TextField as MuiTextField,
+  makeStyles
+} from "@material-ui/core";
+import { refType } from "@material-ui/utils";
+
+const useInputStyles = makeStyles((theme) => ({
+  root: {
+    "position": "relative",
+    "borderRadius": theme.shape.borderRadius,
+    "&:hover $notchedOutline": {
+      borderColor: theme.palette.colors.black40
+    },
+    // Reset on touch devices, it doesn't add specificity
+    "@media (hover: none)": {
+      "&:hover $notchedOutline": {
+        borderColor: theme.palette.colors.black20
+      }
+    },
+    "&$focused $notchedOutline": {
+      borderColor: theme.palette.colors.reactionBlue400,
+      borderWidth: 2
+    },
+    "&$error $notchedOutline": {
+      borderColor: theme.palette.error.main
+    },
+    "&$disabled $notchedOutline": {
+      borderColor: theme.palette.action.disabled
+    },
+    "&$disabled $input": {
+      backgroundColor: theme.palette.colors.black10
+    }
+  },
+  /* Styles applied to the root element if the component is focused. */
+  focused: {},
+  /* Styles applied to the root element if `error={true}`. */
+  error: {},
+  /* Styles applied to the root element if `disabled={true}`. */
+  disabled: {},
+  /* Styles applied to the root element if `startAdornment` is provided. */
+  multiline: {
+    "padding": 0,
+    "backgroundColor": theme.palette.colors.black02,
+    "&$marginDense": {
+      paddingTop: 0
+    }
+  },
+  /* Styles applied to the `NotchedOutline` element. */
+  notchedOutline: {
+    borderColor: theme.palette.colors.black20,
+    padding: "0"
+
+  },
+  input: {
+    backgroundColor: theme.palette.colors.black02,
+    padding: "11.5px 6px",
+    ...theme.typography.body2
+  }
+}));
+
+const useInputLabelStyles = makeStyles((theme) => ({
+  root: {
+    marginBottom: theme.spacing(1),
+    ...theme.typography.h5
+  },
+  formControl: {
+    position: "static",
+    left: 0,
+    top: 0,
+    // slight alteration to spec spacing to match visual spec result
+    // transform: 'translate(0, 24px) scale(1)',
+    transform: "none"
+  },
+  shrink: {
+    transform: "none",
+    transformOrigin: "top left"
+  },
+  outlined: {
+    "transform": "none",
+    "&$shrink": {
+      transform: "none"
+    }
+  }
+}));
+
+const useFormHelperTextStyles = makeStyles((theme) => ({
+  root: {
+    ...theme.typography.body2
+  },
+  contained: {
+    marginLeft: 0,
+    marginRight: 0
+  }
+}));
+
+/**
+ * @name TextField
+ * @param {Object} props Component props
+ * @returns {React.Component} returns a React component
+ */
+const TextField = React.forwardRef(function TextField(props, ref) {
+  const inputClasses = useInputStyles();
+  const inputLabelClasses = useInputLabelStyles();
+  const formHelperTextClasses = useFormHelperTextStyles();
+
+  return (
+    <MuiTextField
+      FormHelperTextProps={{
+        classes: formHelperTextClasses
+      }}
+      InputProps={{
+        classes: inputClasses,
+        disableUnderline: true,
+        notched: false,
+        dense: true
+      }}
+      InputLabelProps={{
+        shrink: true,
+        classes: inputLabelClasses
+      }}
+      fullWidth
+      variant="outlined"
+      {...props}
+      ref={ref}
+    />
+  );
+});
+
+/* eslint-disable react/boolean-prop-naming */
+/**
+ *
+ * The following prop-type definitions are copied from the Material UI TextField component to aide in documentation generation.
+ * Source: [@material-ui/core/TextField](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TextField/TextField.js)
+ */
+TextField.propTypes = {
+  /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  FormHelperTextProps: PropTypes.object,
+  /**
+   * If `true`, the `input` element will be focused during the first mount.
+   */
+  InputLabelProps: PropTypes.object,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Override or extend the styles applied to the component.
+   * See [CSS API](#css) below for more details.
+   */
+  SelectProps: PropTypes.object,
+  /**
+   * @ignore
+   */
+  autoComplete: PropTypes.string,
+  /**
+   * The color of the component. It supports those theme colors that make sense for this component.
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * The default value of the `input` element.
+   */
+  children: PropTypes.node,
+  /**
+   * If `true`, the `input` element will be disabled.
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, the label will be displayed in an error state.
+   */
+  classes: PropTypes.object.isRequired,
+  /**
+   * Props applied to the [`FormHelperText`](/api/form-helper-text/) element.
+   */
+  color: PropTypes.oneOf(["primary", "secondary"]),
+  /**
+   * If `true`, the input will take up the full width of its container.
+   */
+  defaultValue: PropTypes.any,
+  /**
+   * The helper text content.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  error: PropTypes.bool,
+  /**
+   * The id of the `input` element.
+   * Use this prop to make `label` and `helperText` accessible for screen readers.
+   */
+  fullWidth: PropTypes.bool,
+  /**
+   * Props applied to the [`InputLabel`](/api/input-label/) element.
+   */
+  helperText: PropTypes.node,
+  /**
+   * Props applied to the Input element.
+   * It will be a [`FilledInput`](/api/filled-input/),
+   * [`OutlinedInput`](/api/outlined-input/) or [`Input`](/api/input/)
+   * component depending on the `variant` prop value.
+   */
+  hiddenLabel: PropTypes.bool,
+  /**
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+   */
+  id: PropTypes.string,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputProps: PropTypes.object,
+  /**
+   * The label content.
+   */
+  inputRef: refType,
+  /**
+   * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
+   */
+  label: PropTypes.node,
+  /**
+   * If `true`, a textarea element will be rendered instead of an input.
+   */
+  margin: PropTypes.oneOf(["none", "dense", "normal"]),
+  /**
+   * Name attribute of the `input` element.
+   */
+  multiline: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  name: PropTypes.string,
+  /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onBlur: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onChange: PropTypes.func,
+  /**
+   * The short hint displayed in the input before the user enters a value.
+   */
+  onFocus: PropTypes.func,
+  /**
+   * If `true`, the label is displayed as required and the `input` element` will be required.
+   */
+  placeholder: PropTypes.string,
+  /**
+   * Number of rows to display when multiline option is set to true.
+   */
+  required: PropTypes.bool,
+  /**
+   * Maximum number of rows to display when multiline option is set to true.
+   */
+  rows: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * Render a [`Select`](/api/select/) element while passing the Input element to `Select` as `input` parameter.
+   * If this option is set you must pass the options of the select as children.
+   */
+  rowsMax: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * Props applied to the [`Select`](/api/select/) element.
+   */
+  select: PropTypes.bool,
+  /**
+   * The size of the text field.
+   */
+  size: PropTypes.oneOf(["small", "medium"]),
+  /**
+   * Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
+   */
+  type: PropTypes.string,
+  /**
+   * The value of the `input` element, required for a controlled component.
+   */
+  value: PropTypes.any,
+  /**
+   * The variant to use.
+   */
+  variant: PropTypes.oneOf(["standard", "outlined", "filled"])
+};
+/* eslint-enable react/boolean-prop-naming */
+
+export default TextField;

--- a/package/src/components/TextField/TextField.js
+++ b/package/src/components/TextField/TextField.js
@@ -39,6 +39,8 @@ const useInputStyles = makeStyles((theme) => ({
   error: {},
   /* Styles applied to the root element if `disabled={true}`. */
   disabled: {},
+  /* Styles applied to the `input` element if `margin="dense"`. */
+  marginDense: {},
   /* Styles applied to the root element if `startAdornment` is provided. */
   multiline: {
     "padding": 0,

--- a/package/src/components/TextField/TextField.js
+++ b/package/src/components/TextField/TextField.js
@@ -6,6 +6,7 @@ import {
 } from "@material-ui/core";
 import { refType } from "@material-ui/utils";
 
+// Styles for the base input component
 const useInputStyles = makeStyles((theme) => ({
   root: {
     "position": "relative",
@@ -62,6 +63,7 @@ const useInputStyles = makeStyles((theme) => ({
   }
 }));
 
+// Styles for the label above the field
 const useInputLabelStyles = makeStyles((theme) => ({
   root: {
     marginBottom: theme.spacing(1),
@@ -85,6 +87,7 @@ const useInputLabelStyles = makeStyles((theme) => ({
   }
 }));
 
+// Styles for the helper text below the field
 const useFormHelperTextStyles = makeStyles((theme) => ({
   root: {
     ...theme.typography.body2,

--- a/package/src/components/TextField/TextField.js
+++ b/package/src/components/TextField/TextField.js
@@ -85,7 +85,8 @@ const useInputLabelStyles = makeStyles((theme) => ({
 
 const useFormHelperTextStyles = makeStyles((theme) => ({
   root: {
-    ...theme.typography.body2
+    ...theme.typography.body2,
+    color: theme.palette.colors.black55
   },
   contained: {
     marginLeft: 0,

--- a/package/src/components/TextField/TextField.md
+++ b/package/src/components/TextField/TextField.md
@@ -50,10 +50,17 @@ import { MenuItem } from "@material-ui/core";
 import {
   Table,
   TableBody,
-  TableCell,
+  TableCell as MuiTableCell,
   TableHead,
-  TableRow
+  TableRow,
+  withStyles
 } from "@material-ui/core";
+
+const TableCell = withStyles({
+  root: {
+    verticalAlign: "top"
+  }
+})(MuiTableCell);
 
 <Table>
   <TableHead>
@@ -155,7 +162,9 @@ import {
 } from "@material-ui/core";
 
 const TableCell = withStyles({
-  verticalAlign: "top"
+  root: {
+    verticalAlign: "top"
+  }
 })(MuiTableCell);
 
 <Table>

--- a/package/src/components/TextField/TextField.md
+++ b/package/src/components/TextField/TextField.md
@@ -1,0 +1,273 @@
+### Overview
+
+The TextField component is a drop-in replacement for the Material-UI [TextField](https://material-ui.com/components/text-fields/). Refer to the Material-UI [TextField](https://material-ui.com/api/text-field/) for more information.
+
+### Usage
+
+#### Types
+
+##### Single line text field
+
+```jsx
+<TextField
+  label="Label"
+  placeholder="Placeholder text"
+/>
+```
+
+##### Multiline text area
+
+```jsx
+<TextField
+  label="Label"
+  placeholder="Placeholder text"
+  multiline
+/>
+```
+
+##### Select
+
+```jsx
+import { MenuItem } from "@material-ui/core";
+
+
+<TextField
+  label="Label"
+  placeholder="Placeholder text"
+  select
+  defaultValue={1}
+  onChange={(event) => console.log(`Selected option ${event.target.value}`)}
+>
+  <MenuItem value={1}>Option 1</MenuItem>
+  <MenuItem value={2}>Option 2</MenuItem>
+  <MenuItem value={3}>Option 3</MenuItem>
+</TextField>
+```
+
+##### Single line text field states
+
+```jsx
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow
+} from "@material-ui/core";
+
+<Table>
+  <TableHead>
+    <TableRow>
+      <TableCell />
+      <TableCell style={{width: "45%"}} />
+      <TableCell style={{width: "45%"}}>{"With helper text"}</TableCell>
+    </TableRow>
+  </TableHead>
+  <TableBody>
+    <TableRow>
+      <TableCell>{"Enabled"}</TableCell>
+      <TableCell style={{verticalAlign: "top"}}>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+        />
+      </TableCell>
+      <TableCell>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          helperText="Help text"
+        />
+      </TableCell>
+    </TableRow>
+
+    <TableRow>
+      <TableCell>{"Filled"}</TableCell>
+      <TableCell style={{verticalAlign: "top"}}>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          value="User input text"
+        />
+      </TableCell>
+      <TableCell>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          helperText="Help text"
+          value="User input text"
+        />
+      </TableCell>
+    </TableRow>
+
+    <TableRow>
+      <TableCell>{"Disabled"}</TableCell>
+      <TableCell style={{verticalAlign: "top"}}>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          disabled
+        />
+      </TableCell>
+      <TableCell>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          helperText="Help text"
+          disabled
+        />
+      </TableCell>
+    </TableRow>
+
+    <TableRow>
+      <TableCell>{"Error"}</TableCell>
+      <TableCell style={{verticalAlign: "top"}}>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          error
+        />
+      </TableCell>
+      <TableCell>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          helperText="Error, here’s how you can fix it"
+          error
+        />
+      </TableCell>
+    </TableRow>
+  </TableBody>
+</Table>
+
+```
+
+##### Multiline states
+
+```jsx
+import {
+  Table,
+  TableBody,
+  TableCell as MuiTableCell,
+  TableHead,
+  TableRow,
+  withStyles
+} from "@material-ui/core";
+
+const TableCell = withStyles({
+  verticalAlign: "top"
+})(MuiTableCell);
+
+<Table>
+  <TableHead>
+    <TableRow>
+      <TableCell />
+      <TableCell style={{width: "45%"}} />
+      <TableCell style={{width: "45%"}}>{"With helper text"}</TableCell>
+    </TableRow>
+  </TableHead>
+  <TableBody>
+    <TableRow>
+      <TableCell>{"Enabled"}</TableCell>
+      <TableCell style={{verticalAlign: "top"}}>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          multiline
+        />
+      </TableCell>
+      <TableCell>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          helperText="Help text"
+          multiline
+        />
+      </TableCell>
+    </TableRow>
+
+    <TableRow>
+      <TableCell>{"Filled"}</TableCell>
+      <TableCell style={{verticalAlign: "top"}}>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          value="User input text"
+          multiline
+        />
+      </TableCell>
+      <TableCell>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          helperText="Help text"
+          value="User input text"
+          multiline
+        />
+      </TableCell>
+    </TableRow>
+
+    <TableRow>
+      <TableCell>{"Disabled"}</TableCell>
+      <TableCell style={{verticalAlign: "top"}}>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          disabled
+          multiline
+        />
+      </TableCell>
+      <TableCell>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          helperText="Help text"
+          disabled
+        />
+      </TableCell>
+    </TableRow>
+
+    <TableRow>
+      <TableCell>{"Error"}</TableCell>
+      <TableCell style={{verticalAlign: "top"}}>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          error
+          multiline
+        />
+      </TableCell>
+      <TableCell>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          helperText="Error, here’s how you can fix it"
+          error
+          multiline
+        />
+      </TableCell>
+    </TableRow>
+
+    <TableRow>
+      <TableCell>{"Expanded"}</TableCell>
+      <TableCell style={{verticalAlign: "top"}}>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          multiline
+          rows={7}
+        />
+      </TableCell>
+      <TableCell>
+        <TextField
+          label="Label"
+          placeholder="Placeholder text"
+          multiline
+          rows={7}
+        />
+      </TableCell>
+    </TableRow>
+  </TableBody>
+</Table>
+
+```

--- a/package/src/components/TextField/TextField.test.js
+++ b/package/src/components/TextField/TextField.test.js
@@ -1,0 +1,83 @@
+import React from "react";
+import { MenuItem } from "@material-ui/core";
+import { render } from "../../tests/index.js";
+import TextField from "./TextField";
+
+test("snapshot - singleline", () => {
+  const { asFragment } = render(<TextField value="hello" />);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("snapshot - singleline - disabled", () => {
+  const { asFragment } = render(<TextField value="hello" disabled />);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("snapshot - singleline - error", () => {
+  const { asFragment } = render(<TextField value="hello" error helpText="Help text" />);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("snapshot - multiline", () => {
+  const { asFragment } = render(<TextField value="hello" multiline />);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("snapshot - multiline - expanded", () => {
+  const { asFragment } = render(<TextField value="hello" multiline rows={4} />);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("snapshot - multiline - disabled", () => {
+  const { asFragment } = render(<TextField value="hello" multiline disabled />);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("snapshot - multiline - error state", () => {
+  const { asFragment } = render(<TextField value="hello" multiline error helpText="Help text" />);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("snapshot - select", () => {
+  const { asFragment } = render((
+    <TextField
+      value={1}
+      select
+    >
+      <MenuItem value={1}>Option 1</MenuItem>
+      <MenuItem value={2}>Option 2</MenuItem>
+      <MenuItem value={3}>Option 3</MenuItem>
+    </TextField>
+  ));
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("snapshot - select - disabled", () => {
+  const { asFragment } = render((
+    <TextField
+      value={1}
+      select
+      disabled
+    >
+      <MenuItem value={1}>Option 1</MenuItem>
+      <MenuItem value={2}>Option 2</MenuItem>
+      <MenuItem value={3}>Option 3</MenuItem>
+    </TextField>
+  ));
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("snapshot - select - error state", () => {
+  const { asFragment } = render((
+    <TextField
+      value={1}
+      select
+      error
+    >
+      <MenuItem value={1}>Option 1</MenuItem>
+      <MenuItem value={2}>Option 2</MenuItem>
+      <MenuItem value={3}>Option 3</MenuItem>
+    </TextField>
+  ));
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/package/src/components/TextField/__snapshots__/TextField.test.js.snap
+++ b/package/src/components/TextField/__snapshots__/TextField.test.js.snap
@@ -6,11 +6,11 @@ exports[`snapshot - multiline - disabled 1`] = `
     class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-286 Mui-disabled Mui-disabled makeStyles-disabled-289 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-290"
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-291 Mui-disabled Mui-disabled makeStyles-disabled-294 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-296"
     >
       <textarea
         aria-invalid="false"
-        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-292 Mui-disabled Mui-disabled makeStyles-disabled-289 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-298 Mui-disabled Mui-disabled makeStyles-disabled-294 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
         disabled=""
         rows="1"
         style="height: 0px; overflow: hidden;"
@@ -19,18 +19,18 @@ exports[`snapshot - multiline - disabled 1`] = `
       </textarea>
       <textarea
         aria-hidden="true"
-        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-292 Mui-disabled Mui-disabled makeStyles-disabled-289 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-298 Mui-disabled Mui-disabled makeStyles-disabled-294 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
         readonly=""
         style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); width: 100%;"
         tabindex="-1"
       />
       <fieldset
         aria-hidden="true"
-        class="PrivateNotchedOutline-root-339 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-291"
+        class="PrivateNotchedOutline-root-345 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-297"
         style="padding-left: 8px;"
       >
         <legend
-          class="PrivateNotchedOutline-legend-340"
+          class="PrivateNotchedOutline-legend-346"
           style="width: 0.01px;"
         >
           <span>
@@ -50,11 +50,11 @@ exports[`snapshot - multiline - error state 1`] = `
     helptext="Help text"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-343 Mui-error Mui-error makeStyles-error-345 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-347"
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-349 Mui-error Mui-error makeStyles-error-351 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-354"
     >
       <textarea
         aria-invalid="true"
-        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-349 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-356 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
         rows="1"
         style="height: 0px; overflow: hidden;"
       >
@@ -62,18 +62,18 @@ exports[`snapshot - multiline - error state 1`] = `
       </textarea>
       <textarea
         aria-hidden="true"
-        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-349 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-356 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
         readonly=""
         style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); width: 100%;"
         tabindex="-1"
       />
       <fieldset
         aria-hidden="true"
-        class="PrivateNotchedOutline-root-396 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-348"
+        class="PrivateNotchedOutline-root-403 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-355"
         style="padding-left: 8px;"
       >
         <legend
-          class="PrivateNotchedOutline-legend-397"
+          class="PrivateNotchedOutline-legend-404"
           style="width: 0.01px;"
         >
           <span>
@@ -92,22 +92,22 @@ exports[`snapshot - multiline - expanded 1`] = `
     class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-229 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-233"
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-233 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-238"
     >
       <textarea
         aria-invalid="false"
-        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-235 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-240 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
         rows="4"
       >
         hello
       </textarea>
       <fieldset
         aria-hidden="true"
-        class="PrivateNotchedOutline-root-282 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-234"
+        class="PrivateNotchedOutline-root-287 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-239"
         style="padding-left: 8px;"
       >
         <legend
-          class="PrivateNotchedOutline-legend-283"
+          class="PrivateNotchedOutline-legend-288"
           style="width: 0.01px;"
         >
           <span>
@@ -126,11 +126,11 @@ exports[`snapshot - multiline 1`] = `
     class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-172 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-176"
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-175 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-180"
     >
       <textarea
         aria-invalid="false"
-        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-178 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-182 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
         rows="1"
         style="height: 0px; overflow: hidden;"
       >
@@ -138,18 +138,18 @@ exports[`snapshot - multiline 1`] = `
       </textarea>
       <textarea
         aria-hidden="true"
-        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-178 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-182 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
         readonly=""
         style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); width: 100%;"
         tabindex="-1"
       />
       <fieldset
         aria-hidden="true"
-        class="PrivateNotchedOutline-root-225 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-177"
+        class="PrivateNotchedOutline-root-229 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-181"
         style="padding-left: 8px;"
       >
         <legend
-          class="PrivateNotchedOutline-legend-226"
+          class="PrivateNotchedOutline-legend-230"
           style="width: 0.01px;"
         >
           <span>
@@ -168,12 +168,12 @@ exports[`snapshot - select - disabled 1`] = `
     class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-480 Mui-disabled Mui-disabled makeStyles-disabled-483 MuiInputBase-fullWidth MuiInputBase-formControl"
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-488 Mui-disabled Mui-disabled makeStyles-disabled-491 MuiInputBase-fullWidth MuiInputBase-formControl"
     >
       <div
         aria-haspopup="listbox"
         aria-labelledby=" "
-        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input makeStyles-input-486 Mui-disabled Mui-disabled makeStyles-disabled-483 Mui-disabled"
+        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input makeStyles-input-495 Mui-disabled Mui-disabled makeStyles-disabled-491 Mui-disabled"
         role="button"
       >
         Option 1
@@ -195,11 +195,11 @@ exports[`snapshot - select - disabled 1`] = `
       </svg>
       <fieldset
         aria-hidden="true"
-        class="PrivateNotchedOutline-root-556 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-485"
+        class="PrivateNotchedOutline-root-565 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-494"
         style="padding-left: 8px;"
       >
         <legend
-          class="PrivateNotchedOutline-legend-557"
+          class="PrivateNotchedOutline-legend-566"
           style="width: 0.01px;"
         >
           <span>
@@ -218,12 +218,12 @@ exports[`snapshot - select - error state 1`] = `
     class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-560 Mui-error Mui-error makeStyles-error-562 MuiInputBase-fullWidth MuiInputBase-formControl"
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-569 Mui-error Mui-error makeStyles-error-571 MuiInputBase-fullWidth MuiInputBase-formControl"
     >
       <div
         aria-haspopup="listbox"
         aria-labelledby=" "
-        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input makeStyles-input-566"
+        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input makeStyles-input-576"
         role="button"
         tabindex="0"
       >
@@ -246,11 +246,11 @@ exports[`snapshot - select - error state 1`] = `
       </svg>
       <fieldset
         aria-hidden="true"
-        class="PrivateNotchedOutline-root-636 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-565"
+        class="PrivateNotchedOutline-root-646 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-575"
         style="padding-left: 8px;"
       >
         <legend
-          class="PrivateNotchedOutline-legend-637"
+          class="PrivateNotchedOutline-legend-647"
           style="width: 0.01px;"
         >
           <span>
@@ -269,12 +269,12 @@ exports[`snapshot - select 1`] = `
     class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-400 MuiInputBase-fullWidth MuiInputBase-formControl"
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-407 MuiInputBase-fullWidth MuiInputBase-formControl"
     >
       <div
         aria-haspopup="listbox"
         aria-labelledby=" "
-        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input makeStyles-input-406"
+        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input makeStyles-input-414"
         role="button"
         tabindex="0"
       >
@@ -297,11 +297,11 @@ exports[`snapshot - select 1`] = `
       </svg>
       <fieldset
         aria-hidden="true"
-        class="PrivateNotchedOutline-root-476 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-405"
+        class="PrivateNotchedOutline-root-484 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-413"
         style="padding-left: 8px;"
       >
         <legend
-          class="PrivateNotchedOutline-legend-477"
+          class="PrivateNotchedOutline-legend-485"
           style="width: 0.01px;"
         >
           <span>
@@ -320,22 +320,22 @@ exports[`snapshot - singleline - disabled 1`] = `
     class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-58 Mui-disabled Mui-disabled makeStyles-disabled-61 MuiInputBase-fullWidth MuiInputBase-formControl"
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-59 Mui-disabled Mui-disabled makeStyles-disabled-62 MuiInputBase-fullWidth MuiInputBase-formControl"
     >
       <input
         aria-invalid="false"
-        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-64 Mui-disabled Mui-disabled makeStyles-disabled-61"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-66 Mui-disabled Mui-disabled makeStyles-disabled-62"
         disabled=""
         type="text"
         value="hello"
       />
       <fieldset
         aria-hidden="true"
-        class="PrivateNotchedOutline-root-111 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-63"
+        class="PrivateNotchedOutline-root-113 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-65"
         style="padding-left: 8px;"
       >
         <legend
-          class="PrivateNotchedOutline-legend-112"
+          class="PrivateNotchedOutline-legend-114"
           style="width: 0.01px;"
         >
           <span>
@@ -355,21 +355,21 @@ exports[`snapshot - singleline - error 1`] = `
     helptext="Help text"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-115 Mui-error Mui-error makeStyles-error-117 MuiInputBase-fullWidth MuiInputBase-formControl"
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-117 Mui-error Mui-error makeStyles-error-119 MuiInputBase-fullWidth MuiInputBase-formControl"
     >
       <input
         aria-invalid="true"
-        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-121"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-124"
         type="text"
         value="hello"
       />
       <fieldset
         aria-hidden="true"
-        class="PrivateNotchedOutline-root-168 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-120"
+        class="PrivateNotchedOutline-root-171 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-123"
         style="padding-left: 8px;"
       >
         <legend
-          class="PrivateNotchedOutline-legend-169"
+          class="PrivateNotchedOutline-legend-172"
           style="width: 0.01px;"
         >
           <span>
@@ -392,17 +392,17 @@ exports[`snapshot - singleline 1`] = `
     >
       <input
         aria-invalid="false"
-        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-7"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-8"
         type="text"
         value="hello"
       />
       <fieldset
         aria-hidden="true"
-        class="PrivateNotchedOutline-root-54 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-6"
+        class="PrivateNotchedOutline-root-55 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-7"
         style="padding-left: 8px;"
       >
         <legend
-          class="PrivateNotchedOutline-legend-55"
+          class="PrivateNotchedOutline-legend-56"
           style="width: 0.01px;"
         >
           <span>

--- a/package/src/components/TextField/__snapshots__/TextField.test.js.snap
+++ b/package/src/components/TextField/__snapshots__/TextField.test.js.snap
@@ -1,0 +1,416 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot - multiline - disabled 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+  >
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-286 Mui-disabled Mui-disabled makeStyles-disabled-289 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-290"
+    >
+      <textarea
+        aria-invalid="false"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-292 Mui-disabled Mui-disabled makeStyles-disabled-289 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        disabled=""
+        rows="1"
+        style="height: 0px; overflow: hidden;"
+      >
+        hello
+      </textarea>
+      <textarea
+        aria-hidden="true"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-292 Mui-disabled Mui-disabled makeStyles-disabled-289 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        readonly=""
+        style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); width: 100%;"
+        tabindex="-1"
+      />
+      <fieldset
+        aria-hidden="true"
+        class="PrivateNotchedOutline-root-339 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-291"
+        style="padding-left: 8px;"
+      >
+        <legend
+          class="PrivateNotchedOutline-legend-340"
+          style="width: 0.01px;"
+        >
+          <span>
+            ​
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`snapshot - multiline - error state 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+    helptext="Help text"
+  >
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-343 Mui-error Mui-error makeStyles-error-345 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-347"
+    >
+      <textarea
+        aria-invalid="true"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-349 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        rows="1"
+        style="height: 0px; overflow: hidden;"
+      >
+        hello
+      </textarea>
+      <textarea
+        aria-hidden="true"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-349 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        readonly=""
+        style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); width: 100%;"
+        tabindex="-1"
+      />
+      <fieldset
+        aria-hidden="true"
+        class="PrivateNotchedOutline-root-396 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-348"
+        style="padding-left: 8px;"
+      >
+        <legend
+          class="PrivateNotchedOutline-legend-397"
+          style="width: 0.01px;"
+        >
+          <span>
+            ​
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`snapshot - multiline - expanded 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+  >
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-229 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-233"
+    >
+      <textarea
+        aria-invalid="false"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-235 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        rows="4"
+      >
+        hello
+      </textarea>
+      <fieldset
+        aria-hidden="true"
+        class="PrivateNotchedOutline-root-282 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-234"
+        style="padding-left: 8px;"
+      >
+        <legend
+          class="PrivateNotchedOutline-legend-283"
+          style="width: 0.01px;"
+        >
+          <span>
+            ​
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`snapshot - multiline 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+  >
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-172 MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline makeStyles-multiline-176"
+    >
+      <textarea
+        aria-invalid="false"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-178 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        rows="1"
+        style="height: 0px; overflow: hidden;"
+      >
+        hello
+      </textarea>
+      <textarea
+        aria-hidden="true"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-178 MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+        readonly=""
+        style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); width: 100%;"
+        tabindex="-1"
+      />
+      <fieldset
+        aria-hidden="true"
+        class="PrivateNotchedOutline-root-225 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-177"
+        style="padding-left: 8px;"
+      >
+        <legend
+          class="PrivateNotchedOutline-legend-226"
+          style="width: 0.01px;"
+        >
+          <span>
+            ​
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`snapshot - select - disabled 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+  >
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-480 Mui-disabled Mui-disabled makeStyles-disabled-483 MuiInputBase-fullWidth MuiInputBase-formControl"
+    >
+      <div
+        aria-haspopup="listbox"
+        aria-labelledby=" "
+        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input makeStyles-input-486 Mui-disabled Mui-disabled makeStyles-disabled-483 Mui-disabled"
+        role="button"
+      >
+        Option 1
+      </div>
+      <input
+        type="hidden"
+        value="1"
+      />
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+        focusable="false"
+        role="presentation"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M7 10l5 5 5-5z"
+        />
+      </svg>
+      <fieldset
+        aria-hidden="true"
+        class="PrivateNotchedOutline-root-556 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-485"
+        style="padding-left: 8px;"
+      >
+        <legend
+          class="PrivateNotchedOutline-legend-557"
+          style="width: 0.01px;"
+        >
+          <span>
+            ​
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`snapshot - select - error state 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+  >
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-560 Mui-error Mui-error makeStyles-error-562 MuiInputBase-fullWidth MuiInputBase-formControl"
+    >
+      <div
+        aria-haspopup="listbox"
+        aria-labelledby=" "
+        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input makeStyles-input-566"
+        role="button"
+        tabindex="0"
+      >
+        Option 1
+      </div>
+      <input
+        type="hidden"
+        value="1"
+      />
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+        focusable="false"
+        role="presentation"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M7 10l5 5 5-5z"
+        />
+      </svg>
+      <fieldset
+        aria-hidden="true"
+        class="PrivateNotchedOutline-root-636 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-565"
+        style="padding-left: 8px;"
+      >
+        <legend
+          class="PrivateNotchedOutline-legend-637"
+          style="width: 0.01px;"
+        >
+          <span>
+            ​
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`snapshot - select 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+  >
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-400 MuiInputBase-fullWidth MuiInputBase-formControl"
+    >
+      <div
+        aria-haspopup="listbox"
+        aria-labelledby=" "
+        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input makeStyles-input-406"
+        role="button"
+        tabindex="0"
+      >
+        Option 1
+      </div>
+      <input
+        type="hidden"
+        value="1"
+      />
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+        focusable="false"
+        role="presentation"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M7 10l5 5 5-5z"
+        />
+      </svg>
+      <fieldset
+        aria-hidden="true"
+        class="PrivateNotchedOutline-root-476 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-405"
+        style="padding-left: 8px;"
+      >
+        <legend
+          class="PrivateNotchedOutline-legend-477"
+          style="width: 0.01px;"
+        >
+          <span>
+            ​
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`snapshot - singleline - disabled 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+  >
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-58 Mui-disabled Mui-disabled makeStyles-disabled-61 MuiInputBase-fullWidth MuiInputBase-formControl"
+    >
+      <input
+        aria-invalid="false"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-64 Mui-disabled Mui-disabled makeStyles-disabled-61"
+        disabled=""
+        type="text"
+        value="hello"
+      />
+      <fieldset
+        aria-hidden="true"
+        class="PrivateNotchedOutline-root-111 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-63"
+        style="padding-left: 8px;"
+      >
+        <legend
+          class="PrivateNotchedOutline-legend-112"
+          style="width: 0.01px;"
+        >
+          <span>
+            ​
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`snapshot - singleline - error 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+    helptext="Help text"
+  >
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-115 Mui-error Mui-error makeStyles-error-117 MuiInputBase-fullWidth MuiInputBase-formControl"
+    >
+      <input
+        aria-invalid="true"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-121"
+        type="text"
+        value="hello"
+      />
+      <fieldset
+        aria-hidden="true"
+        class="PrivateNotchedOutline-root-168 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-120"
+        style="padding-left: 8px;"
+      >
+        <legend
+          class="PrivateNotchedOutline-legend-169"
+          style="width: 0.01px;"
+        >
+          <span>
+            ​
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`snapshot - singleline 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+  >
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root makeStyles-root-1 MuiInputBase-fullWidth MuiInputBase-formControl"
+    >
+      <input
+        aria-invalid="false"
+        class="MuiInputBase-input MuiOutlinedInput-input makeStyles-input-7"
+        type="text"
+        value="hello"
+      />
+      <fieldset
+        aria-hidden="true"
+        class="PrivateNotchedOutline-root-54 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-6"
+        style="padding-left: 8px;"
+      >
+        <legend
+          class="PrivateNotchedOutline-legend-55"
+          style="width: 0.01px;"
+        >
+          <span>
+            ​
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/package/src/components/TextField/index.js
+++ b/package/src/components/TextField/index.js
@@ -1,0 +1,1 @@
+export { default } from "./TextField";

--- a/package/src/theme/defaultTheme.js
+++ b/package/src/theme/defaultTheme.js
@@ -65,6 +65,9 @@ export const rawMuiTheme = {
     action: {
       hover: colors.reactionBlue100,
       selected: colors.black10
+    },
+    error: {
+      main: colors.red
     }
   },
   typography: {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -372,7 +372,8 @@ module.exports = {
         }),
         generateSection({
           componentNames: [
-            "Select"
+            "Select",
+            "TextField"
           ],
           name: "Inputs"
         }),


### PR DESCRIPTION
Resolves #140
Impact: **minor**
Type: **feature**

## Component

This is a drop-in replacement for the standard MUI TextField component that defaults to the outlined style. Styles have been updated to match the Catalyst spec, otherwise, it's a standard MUI TextField under the hood.

This gives us all of its features including
- Single line text input
- Multiline text input
- Select dropdown (works well for forms with validation)

## Screenshots

![image](https://user-images.githubusercontent.com/42217/73289144-0826d180-41b1-11ea-8ad8-fc5fe68d1256.png)

![image](https://user-images.githubusercontent.com/42217/73289172-1674ed80-41b1-11ea-885f-3f940a8f5600.png)

## Breaking changes

none

## Testing
1. Test the TextField components, mostly visually as the only real change is styling from MUI
