### PR TITLE
feat: Add useComfirmDialog hook

### DIFF
--- a/package/src/components/ConfirmDialog/ConfirmDialog.js
+++ b/package/src/components/ConfirmDialog/ConfirmDialog.js
@@ -1,6 +1,6 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
-import ConfirmDialogBase from "./helpers/ConfirmDialogBase";
+import useConfirmDialog from "./helpers/useConfirmDialog";
 
 /**
  * @name ConfirmDialog
@@ -8,27 +8,22 @@ import ConfirmDialogBase from "./helpers/ConfirmDialogBase";
  * @returns {React.Component} A React component
  */
 const ConfirmDialog = React.forwardRef(function ConfirmDialog(props, ref) {
-  const { children, content, ...otherProps } = props;
-  const [isOpen, setOpen] = useState(false);
-
-  const handleClose = () => {
-    setOpen(false);
-  };
+  const { children, ...otherProps } = props;
+  const {
+    isOpen,
+    openDialog,
+    closeDialog,
+    ConfirmDialog: ConfirmDialogComponent
+  } = useConfirmDialog({ ...otherProps });
 
   return (
     <Fragment>
       {children({
-        openDialog: () => {
-          setOpen(true);
-        }
+        closeDialog,
+        isOpen,
+        openDialog
       })}
-      <ConfirmDialogBase
-        isOpen={isOpen}
-        onClose={handleClose}
-        ref={ref}
-        children={content}
-        {...otherProps}
-      />
+      <ConfirmDialogComponent ref={ref} />
     </Fragment>
   );
 });
@@ -40,7 +35,7 @@ ConfirmDialog.propTypes = {
    */
   cancelActionText: PropTypes.string,
   /**
-   * Render prop `{({ openDialog }) => ()}`
+   * Render prop `{({ closeDialog, isOpen, openDialog }) => ()}`
    */
   children: PropTypes.func,
   /**

--- a/package/src/components/ConfirmDialog/ConfirmDialog.js
+++ b/package/src/components/ConfirmDialog/ConfirmDialog.js
@@ -1,11 +1,6 @@
 import React, { Fragment, useState } from "react";
 import PropTypes from "prop-types";
-import Button from "@material-ui/core/Button";
-import Dialog from "@material-ui/core/Dialog";
-import DialogActions from "@material-ui/core/DialogActions";
-import DialogContent from "@material-ui/core/DialogContent";
-import DialogContentText from "@material-ui/core/DialogContentText";
-import DialogTitle from "../DialogTitle";
+import ConfirmDialogBase from "./helpers/ConfirmDialogBase";
 
 /**
  * @name ConfirmDialog
@@ -13,51 +8,27 @@ import DialogTitle from "../DialogTitle";
  * @returns {React.Component} A React component
  */
 const ConfirmDialog = React.forwardRef(function ConfirmDialog(props, ref) {
-  const { children, title, message, confirmActionText, cancelActionText, onConfirm } = props;
-  const [isOpen, setIsOpen] = useState(false);
+  const { children, content, ...otherProps } = props;
+  const [isOpen, setOpen] = useState(false);
 
   const handleClose = () => {
-    setIsOpen(false);
+    setOpen(false);
   };
 
   return (
     <Fragment>
       {children({
         openDialog: () => {
-          setIsOpen(true);
+          setOpen(true);
         }
       })}
-      <Dialog
-        aria-labelledby="confirm-action-dialog-title"
-        maxWidth="sm"
-        fullWidth={true}
+      <ConfirmDialogBase
+        isOpen={isOpen}
         onClose={handleClose}
-        open={isOpen}
         ref={ref}
-      >
-        <DialogTitle id="confirm-action-dialog-title">{title}</DialogTitle>
-        {message && (
-          <DialogContent>
-            <DialogContentText>{message}</DialogContentText>
-          </DialogContent>
-        )}
-
-        <DialogActions>
-          <Button onClick={handleClose} color="primary" variant="outlined">
-            {cancelActionText}
-          </Button>
-          <Button
-            onClick={() => {
-              onConfirm();
-              setIsOpen(false);
-            }}
-            color="primary"
-            variant="contained"
-          >
-            {confirmActionText}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        children={content}
+        {...otherProps}
+      />
     </Fragment>
   );
 });
@@ -71,15 +42,27 @@ ConfirmDialog.propTypes = {
   /**
    * Render prop `{({ openDialog }) => ()}`
    */
-  children: PropTypes.func.isRequired,
+  children: PropTypes.func,
   /**
    * Text for confirm button
    */
   confirmActionText: PropTypes.string,
   /**
-   * Message body. May be a string or a React component.
+   * Child elements of the dialog. Use if this for rendering a custom components in the dialog.
+  */
+  content: PropTypes.element,
+  /**
+   * Dialog open/close state
+   */
+  isOpen: PropTypes.bool,
+  /**
+   * Message body. May be a string or a React component. Use if your message is mostly text.
    */
   message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /**
+   * Close callback
+   */
+  onClose: PropTypes.func,
   /**
    * Confirmation callback
    */
@@ -93,6 +76,7 @@ ConfirmDialog.propTypes = {
 ConfirmDialog.defaultProps = {
   cancelActionText: "Cancel",
   confirmActionText: "OK",
+  onClose() { },
   onConfirm() { }
 };
 

--- a/package/src/components/ConfirmDialog/ConfirmDialog.md
+++ b/package/src/components/ConfirmDialog/ConfirmDialog.md
@@ -6,6 +6,105 @@ The `ConfirmDialog` component uses [Dialog](https://material-ui.com/api/dialog),
 
 The `ConfirmDialog` component provides a standard confirmation alert base on some user action. Pass a callback function to `onConfirm()` to allow the user to take an action after clicking the confirmation button.
 
+
+### Open Confirm dialog with a hook
+
+This example shows how you can use the can use the confirm dialog with the `useConfirmDialog` hook. This method can also be used to open the dialog when there is no direct user interaction.
+
+The hook `useConfirmDialog` accepts some of the same props as the `ConfirmDialog` component. The usage of the `useConfirmDialog` hook, and the available props are outlined in the examples below.
+
+```js static
+const {
+  isOpen, // Boolean: Open state
+  openDialog, // Function: Open dialog
+  closeDialog, // Function: Close dialog
+  dialog // React.Element: Render the dialog. Must be place somewhere in your rendered component.
+} = useConfirmDialog({
+  /* Available props */
+  cancelActionText: "Cancel", // Optional: Default `Cancel`
+  closeOnConfirm: true, // Optional: Default `true`. Should the dialog close on confirm.
+  confirmActionText: "Ok", // Optional: Default `OK`
+  content: <div></div>, // Content of the dialog. May be used alongside `message`
+  message: "", // Text content of the dialog. May be used alongside `content`
+  onClose: () => {}, // Callback on close. This is called after the dialog has been closed.
+  onConfirm: () => {}, // Callback on confirmation.
+  title // Title of the dialog.
+});
+```
+
+```jsx
+import Button from "../Button";
+import useConfirmDialog from "./helpers/useConfirmDialog"
+
+function MyComponent() {
+  const {
+    isOpen, // Boolean: Open state
+    openDialog, // Function: Open dialog
+    closeDialog, // Function: Close dialog
+    dialog // React.Element: Render the dialog. Add somewhere in your component
+  } = useConfirmDialog({ // ConfirmDialog props (see above example)
+    title: "Archive 24 products?",
+    message: "Archiving products removes them from both admin and customer views.",
+    onConfirm: () => {
+      alert("Action confirmed!")
+    },
+    onClose: () => {
+      console.log("Dialog closed")
+    }
+  })
+
+  return (
+    <>
+      <Button color="primary" onClick={openDialog} variant="contained">Open Confirm Dialog</Button>
+      {dialog}
+    </>
+  )
+}
+
+MyComponent();
+```
+
+### Confirm dialog with additional content
+
+```jsx
+import { Avatar, List, ListItem, ListItemText, ListItemAvatar } from "@material-ui/core";
+import Button from "../Button";
+import useConfirmDialog from "./helpers/useConfirmDialog"
+
+function MyComponent() {
+  const { dialog, openDialog } = useConfirmDialog({
+    title: "Update account permissions?",
+    message: "Are you sure you want to update the permissions the following account(s)?",
+    content: (
+      <List>
+        <ListItem>
+          <ListItemAvatar>
+            <Avatar>RC</Avatar>
+          </ListItemAvatar>
+          <ListItemText>
+            Reaction Commerce
+          </ListItemText>
+        </ListItem>
+      </List>
+    ),
+    onConfirm: () => {
+      alert("Action confirmed!")
+    }
+  })
+
+  return (
+    <>
+      <Button color="primary" onClick={openDialog} variant="contained">Open Confirm Dialog</Button>
+      {dialog}
+    </>
+  )
+}
+
+MyComponent();
+```
+
+### Basic usage
+
 ```jsx
 import Button from "../Button";
 

--- a/package/src/components/ConfirmDialog/ConfirmDialog.md
+++ b/package/src/components/ConfirmDialog/ConfirmDialog.md
@@ -18,7 +18,7 @@ const {
   isOpen, // Boolean: Open state
   openDialog, // Function: Open dialog
   closeDialog, // Function: Close dialog
-  dialog // React.Element: Render the dialog. Must be place somewhere in your rendered component.
+  ConfirmDialog // React.Element: Render the dialog. Must be place somewhere in your rendered component.
 } = useConfirmDialog({
   /* Available props */
   cancelActionText: "Cancel", // Optional: Default `Cancel`
@@ -41,7 +41,7 @@ function MyComponent() {
     isOpen, // Boolean: Open state
     openDialog, // Function: Open dialog
     closeDialog, // Function: Close dialog
-    dialog // React.Element: Render the dialog. Add somewhere in your component
+    ConfirmDialog // React.Element: Render the dialog. Add somewhere in your component
   } = useConfirmDialog({ // ConfirmDialog props (see above example)
     title: "Archive 24 products?",
     message: "Archiving products removes them from both admin and customer views.",
@@ -56,7 +56,7 @@ function MyComponent() {
   return (
     <>
       <Button color="primary" onClick={openDialog} variant="contained">Open Confirm Dialog</Button>
-      {dialog}
+      <ConfirmDialog />
     </>
   )
 }
@@ -72,7 +72,7 @@ import Button from "../Button";
 import useConfirmDialog from "./helpers/useConfirmDialog"
 
 function MyComponent() {
-  const { dialog, openDialog } = useConfirmDialog({
+  const { ConfirmDialog, openDialog } = useConfirmDialog({
     title: "Update account permissions?",
     message: "Are you sure you want to update the permissions the following account(s)?",
     content: (
@@ -95,7 +95,7 @@ function MyComponent() {
   return (
     <>
       <Button color="primary" onClick={openDialog} variant="contained">Open Confirm Dialog</Button>
-      {dialog}
+      <ConfirmDialog />
     </>
   )
 }

--- a/package/src/components/ConfirmDialog/ConfirmDialog.md
+++ b/package/src/components/ConfirmDialog/ConfirmDialog.md
@@ -7,7 +7,7 @@ The `ConfirmDialog` component uses [Dialog](https://material-ui.com/api/dialog),
 The `ConfirmDialog` component provides a standard confirmation alert base on some user action. Pass a callback function to `onConfirm()` to allow the user to take an action after clicking the confirmation button.
 
 
-### Open Confirm dialog with a hook
+#### Open Confirm dialog with a hook
 
 This example shows how you can use the can use the confirm dialog with the `useConfirmDialog` hook. This method can also be used to open the dialog when there is no direct user interaction.
 
@@ -64,7 +64,7 @@ function MyComponent() {
 MyComponent();
 ```
 
-### Confirm dialog with additional content
+#### Confirm dialog with additional content
 
 ```jsx
 import { Avatar, List, ListItem, ListItemText, ListItemAvatar } from "@material-ui/core";
@@ -103,7 +103,7 @@ function MyComponent() {
 MyComponent();
 ```
 
-### Basic usage
+#### Basic usage
 
 ```jsx
 import Button from "../Button";

--- a/package/src/components/ConfirmDialog/ConfirmDialog.test.js
+++ b/package/src/components/ConfirmDialog/ConfirmDialog.test.js
@@ -53,3 +53,33 @@ test("basic snapshot - with opening the dialog using the useConfirmDialog hook",
   expect(getByRole("dialog")).toMatchSnapshot();
   expect(asFragment()).toMatchSnapshot();
 });
+
+test("basic snapshot - with opening the dialog using the useConfirmDialog hook with more content", () => {
+  // eslint-disable-next-line require-jsdoc, react/no-multi-comp
+  function TestComponent() {
+    const { openDialog, ConfirmDialog: ConfirmDialogComponent } = useConfirmDialog({
+      title: "Are you sure?",
+      content: <span>More content</span>,
+      message: "Are you sure you want to do that?"
+    });
+
+    return (
+      <>
+        <Button color="primary" onClick={openDialog} variant="contained">Open Confirm Dialog</Button>
+        <ConfirmDialogComponent />
+      </>
+    );
+  }
+
+  const { asFragment, getByText, getByRole } = render(<TestComponent />);
+
+  fireEvent.click(getByText("Open Confirm Dialog"));
+  expect(getByRole("dialog")).toBeInTheDocument();
+  expect(getByRole("dialog")).toHaveTextContent("Are you sure you want to do that?");
+  expect(getByRole("dialog")).toHaveTextContent("More content");
+  expect(getByRole("dialog")).toHaveTextContent("Are you sure?");
+  expect(getByRole("dialog")).toHaveTextContent("OK");
+  expect(getByRole("dialog")).toHaveTextContent("Cancel");
+  expect(getByRole("dialog")).toMatchSnapshot();
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/package/src/components/ConfirmDialog/ConfirmDialog.test.js
+++ b/package/src/components/ConfirmDialog/ConfirmDialog.test.js
@@ -29,15 +29,15 @@ test("basic snapshot - with opening the dialog", () => {
 test("basic snapshot - with opening the dialog using the useConfirmDialog hook", () => {
   // eslint-disable-next-line require-jsdoc
   function TestComponent() {
-    const { openDialog, dialog } = useConfirmDialog({
+    const { openDialog, ConfirmDialog: ConfirmDialogComponent } = useConfirmDialog({
       title: "Are you sure?",
       message: "Are you sure you want to do that?"
     });
 
     return (
       <>
-        {dialog}
         <Button color="primary" onClick={openDialog} variant="contained">Open Confirm Dialog</Button>
+        <ConfirmDialogComponent />
       </>
     );
   }

--- a/package/src/components/ConfirmDialog/ConfirmDialog.test.js
+++ b/package/src/components/ConfirmDialog/ConfirmDialog.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { render, fireEvent } from "../../tests/";
 import Button from "../Button";
 import ConfirmDialog from "./ConfirmDialog";
+import useConfirmDialog from "./helpers/useConfirmDialog";
 
 test("basic snapshot - with opening the dialog", () => {
   /* eslint-disable function-paren-newline */
@@ -14,6 +15,35 @@ test("basic snapshot - with opening the dialog", () => {
         <Button color="primary" onClick={openDialog} variant="contained">Open Confirm Dialog</Button>
       )}
     </ConfirmDialog>);
+  fireEvent.click(getByText("Open Confirm Dialog"));
+  expect(getByRole("dialog")).toBeInTheDocument();
+  expect(getByRole("dialog")).toHaveTextContent("Are you sure you want to do that?");
+  expect(getByRole("dialog")).toHaveTextContent("Are you sure?");
+  expect(getByRole("dialog")).toHaveTextContent("OK");
+  expect(getByRole("dialog")).toHaveTextContent("Cancel");
+  expect(getByRole("dialog")).toMatchSnapshot();
+  expect(asFragment()).toMatchSnapshot();
+});
+
+
+test("basic snapshot - with opening the dialog using the useConfirmDialog hook", () => {
+  // eslint-disable-next-line require-jsdoc
+  function TestComponent() {
+    const { openDialog, dialog } = useConfirmDialog({
+      title: "Are you sure?",
+      message: "Are you sure you want to do that?"
+    });
+
+    return (
+      <>
+        {dialog}
+        <Button color="primary" onClick={openDialog} variant="contained">Open Confirm Dialog</Button>
+      </>
+    );
+  }
+
+  const { asFragment, getByText, getByRole } = render(<TestComponent />);
+
   fireEvent.click(getByText("Open Confirm Dialog"));
   expect(getByRole("dialog")).toBeInTheDocument();
   expect(getByRole("dialog")).toHaveTextContent("Are you sure you want to do that?");

--- a/package/src/components/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
+++ b/package/src/components/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
@@ -157,3 +157,89 @@ exports[`basic snapshot - with opening the dialog using the useConfirmDialog hoo
   </button>
 </DocumentFragment>
 `;
+
+exports[`basic snapshot - with opening the dialog using the useConfirmDialog hook with more content 1`] = `
+<div
+  aria-labelledby="confirm-action-dialog-title"
+  class="MuiPaper-root MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth MuiPaper-elevation24 MuiPaper-rounded"
+  role="dialog"
+>
+  <div
+    class="MuiDialogTitle-root"
+    id="confirm-action-dialog-title"
+  >
+    <h2
+      class="MuiTypography-root MuiTypography-h4"
+    >
+      Are you sure?
+    </h2>
+  </div>
+  <div
+    class="MuiDialogContent-root"
+  >
+    <p
+      class="MuiTypography-root MuiDialogContentText-root MuiTypography-body1 MuiTypography-colorInherit"
+    >
+      Are you sure you want to do that?
+    </p>
+  </div>
+  <div
+    class="MuiDialogContent-root"
+  >
+    <span>
+      More content
+    </span>
+  </div>
+  <div
+    class="MuiDialogActions-root MuiDialogActions-spacing"
+  >
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-label"
+      >
+        Cancel
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-label"
+      >
+        OK
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`basic snapshot - with opening the dialog using the useConfirmDialog hook with more content 2`] = `
+<DocumentFragment>
+  <button
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      Open Confirm Dialog
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</DocumentFragment>
+`;

--- a/package/src/components/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
+++ b/package/src/components/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
@@ -78,3 +78,82 @@ exports[`basic snapshot - with opening the dialog 2`] = `
   </button>
 </DocumentFragment>
 `;
+
+exports[`basic snapshot - with opening the dialog using the useConfirmDialog hook 1`] = `
+<div
+  aria-labelledby="confirm-action-dialog-title"
+  class="MuiPaper-root MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth MuiPaper-elevation24 MuiPaper-rounded"
+  role="dialog"
+>
+  <div
+    class="MuiDialogTitle-root"
+    id="confirm-action-dialog-title"
+  >
+    <h2
+      class="MuiTypography-root MuiTypography-h4"
+    >
+      Are you sure?
+    </h2>
+  </div>
+  <div
+    class="MuiDialogContent-root"
+  >
+    <p
+      class="MuiTypography-root MuiDialogContentText-root MuiTypography-body1 MuiTypography-colorInherit"
+    >
+      Are you sure you want to do that?
+    </p>
+  </div>
+  <div
+    class="MuiDialogActions-root MuiDialogActions-spacing"
+  >
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-label"
+      >
+        Cancel
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-label"
+      >
+        OK
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`basic snapshot - with opening the dialog using the useConfirmDialog hook 2`] = `
+<DocumentFragment>
+  <button
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      Open Confirm Dialog
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</DocumentFragment>
+`;

--- a/package/src/components/ConfirmDialog/helpers/ConfirmDialogBase.js
+++ b/package/src/components/ConfirmDialog/helpers/ConfirmDialogBase.js
@@ -1,0 +1,110 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "../../DialogTitle";
+
+/**
+ * @name ConfirmDialogBase
+ * @param {Object} props Component props
+ * @returns {React.Component} A React component
+ */
+const ConfirmDialogBase = React.forwardRef(function ConfirmDialogBase(props, ref) {
+  const {
+    cancelActionText,
+    children,
+    confirmActionText,
+    isOpen,
+    onClose,
+    message,
+    onConfirm,
+    title,
+    ...otherProps
+  } = props;
+
+  return (
+    <Dialog
+      aria-labelledby="confirm-action-dialog-title"
+      maxWidth="sm"
+      fullWidth={true}
+      onClose={onClose}
+      open={isOpen}
+      ref={ref}
+      {...otherProps}
+    >
+      <DialogTitle id="confirm-action-dialog-title">{title}</DialogTitle>
+      {message && (
+        <DialogContent>
+          <DialogContentText>{message}</DialogContentText>
+        </DialogContent>
+      )}
+
+      {children && (
+        <DialogContent>
+          {children}
+        </DialogContent>
+      )}
+
+      <DialogActions>
+        <Button onClick={onClose} color="primary" variant="outlined">
+          {cancelActionText}
+        </Button>
+        <Button
+          onClick={onConfirm}
+          color="primary"
+          variant="contained"
+        >
+          {confirmActionText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+});
+
+
+ConfirmDialogBase.propTypes = {
+  /**
+   * Cancel button text
+   */
+  cancelActionText: PropTypes.string,
+  /**
+   * Child elements of the dialog
+   */
+  children: PropTypes.element,
+  /**
+   * Text for confirm button
+   */
+  confirmActionText: PropTypes.string,
+  /**
+   * Dialog open/close state
+   */
+  isOpen: PropTypes.bool,
+  /**
+   * Message body. May be a string or a React component.
+   */
+  message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /**
+   * Close callback
+   */
+  onClose: PropTypes.func,
+  /**
+   * Confirmation callback
+   */
+  onConfirm: PropTypes.func,
+  /**
+   * Dialog title
+   */
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+};
+
+ConfirmDialogBase.defaultProps = {
+  cancelActionText: "Cancel",
+  confirmActionText: "OK",
+  onClose() { },
+  onConfirm() { }
+};
+
+export default ConfirmDialogBase;

--- a/package/src/components/ConfirmDialog/helpers/useConfirmDialog.js
+++ b/package/src/components/ConfirmDialog/helpers/useConfirmDialog.js
@@ -15,6 +15,8 @@ import ConfirmDialogBase from "./ConfirmDialogBase";
  * @returns {Object} An object containing {openDialog: func, dialog: React.Element}
  */
 export default function useConfirmDialog({
+  content,
+  children,
   closeOnConfirm = true,
   onClose = () => { },
   onConfirm = () => { },
@@ -45,6 +47,7 @@ export default function useConfirmDialog({
           isOpen={isOpen}
           onClose={closeDialog}
           onConfirm={handleConfirm}
+          children={content || children}
           {...props}
         />
       );

--- a/package/src/components/ConfirmDialog/helpers/useConfirmDialog.js
+++ b/package/src/components/ConfirmDialog/helpers/useConfirmDialog.js
@@ -39,13 +39,15 @@ export default function useConfirmDialog({
     isOpen,
     openDialog,
     closeDialog,
-    dialog: (
-      <ConfirmDialogBase
-        isOpen={isOpen}
-        onClose={closeDialog}
-        onConfirm={handleConfirm}
-        {...props}
-      />
-    )
+    ConfirmDialog() {
+      return (
+        <ConfirmDialogBase
+          isOpen={isOpen}
+          onClose={closeDialog}
+          onConfirm={handleConfirm}
+          {...props}
+        />
+      );
+    }
   };
 }

--- a/package/src/components/ConfirmDialog/helpers/useConfirmDialog.js
+++ b/package/src/components/ConfirmDialog/helpers/useConfirmDialog.js
@@ -5,11 +5,9 @@ import ConfirmDialogBase from "./ConfirmDialogBase";
  * @summary React hook for creating detached confirm dialogs with ease
  * @param {Object} props Props to configure a confirm dialog
  * @param {String} props.cancelActionText Cancel button text
- * @param {Function} props.children Render prop `{({ openDialog }) => ()}`
  * @param {Boolean} props.closeOnConfirm Close dialog on confirmation. Default `true`
  * @param {String} props.confirmActionText Text for confirm button
  * @param {ReactElement} props.content Child elements of the dialog. Use if this for rendering a custom components in the dialog.
- * @param {Boolean} props.isOpen Dialog open/close state
  * @param {String|React.Element} props.message Message body. May be a String or a React component. Use if your message is mostly text.
  * @param {Function} props.onClose Close callback
  * @param {Function} props.onConfirm Confirmation callback
@@ -18,13 +16,17 @@ import ConfirmDialogBase from "./ConfirmDialogBase";
  */
 export default function useConfirmDialog({
   closeOnConfirm = true,
-  onConfirm = () => {},
+  onClose = () => { },
+  onConfirm = () => { },
   ...props
 }) {
   const [isOpen, setOpen] = useState(false);
 
   const openDialog = () => setOpen(true);
-  const closeDialog = () => setOpen(false);
+  const closeDialog = () => {
+    setOpen(false);
+    onClose();
+  };
   const handleConfirm = () => {
     onConfirm();
 

--- a/package/src/components/ConfirmDialog/helpers/useConfirmDialog.js
+++ b/package/src/components/ConfirmDialog/helpers/useConfirmDialog.js
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import ConfirmDialogBase from "./ConfirmDialogBase";
+
+/**
+ * @summary React hook for creating detached confirm dialogs with ease
+ * @param {Object} props Props to configure a confirm dialog
+ * @param {String} props.cancelActionText Cancel button text
+ * @param {Function} props.children Render prop `{({ openDialog }) => ()}`
+ * @param {Boolean} props.closeOnConfirm Close dialog on confirmation. Default `true`
+ * @param {String} props.confirmActionText Text for confirm button
+ * @param {ReactElement} props.content Child elements of the dialog. Use if this for rendering a custom components in the dialog.
+ * @param {Boolean} props.isOpen Dialog open/close state
+ * @param {String|React.Element} props.message Message body. May be a String or a React component. Use if your message is mostly text.
+ * @param {Function} props.onClose Close callback
+ * @param {Function} props.onConfirm Confirmation callback
+ * @param {String|React.Element} props.title Dialog title
+ * @returns {Object} An object containing {openDialog: func, dialog: React.Element}
+ */
+export default function useConfirmDialog({
+  closeOnConfirm = true,
+  onConfirm = () => {},
+  ...props
+}) {
+  const [isOpen, setOpen] = useState(false);
+
+  const openDialog = () => setOpen(true);
+  const closeDialog = () => setOpen(false);
+  const handleConfirm = () => {
+    onConfirm();
+
+    if (closeOnConfirm) {
+      closeDialog();
+    }
+  };
+
+  return {
+    isOpen,
+    openDialog,
+    closeDialog,
+    dialog: (
+      <ConfirmDialogBase
+        isOpen={isOpen}
+        onClose={closeDialog}
+        onConfirm={handleConfirm}
+        {...props}
+      />
+    )
+  };
+}

--- a/package/src/components/ConfirmDialog/index.js
+++ b/package/src/components/ConfirmDialog/index.js
@@ -1,1 +1,4 @@
 export { default } from "./ConfirmDialog";
+export { default as ConfirmDialogBase } from "./helpers/ConfirmDialogBase";
+export { default as useConfirmDialog } from "./helpers/useConfirmDialog";
+

--- a/package/src/index.js
+++ b/package/src/index.js
@@ -1,1 +1,12 @@
+export { default as ActionMenu } from "./components/ActionMenu";
+export { default as Button } from "./components/Button";
+export { default as Chip } from "./components/Chip";
+export { default as ConfirmDialog, ConfirmDialogBase, useConfirmDialog } from "./components/ConfirmDialog";
+export { default as DataTable, useDataTable } from "./components/DataTable";
+export { default as DataTableFilter } from "./components/DataTableFilter";
+export { default as DialogTitle } from "./components/DialogTitle";
+export { default as Select } from "./components/Select";
+export { default as SplitButton } from "./components/SplitButton";
+export { default as TextField } from "./components/TextField";
+export { default as Toast } from "./components/Toast";
 export { default as defaultTheme } from "./theme/defaultTheme";

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -425,7 +425,7 @@ module.exports = {
   },
   getComponentPathLine(componentPath) {
     const name = path.basename(componentPath, ".js");
-    return `import ${name} from "@reactioncommerce/catalyst/${name}"`;
+    return `import { ${name} } from "@reactioncommerce/catalyst"`;
   },
   pagePerSection: true,
   exampleMode: "collapse",


### PR DESCRIPTION
Resolves #150
Impact: **minor**
Type: **feature**

## Component

Add `useConfirmDialog` hook which allows for opening a confirmation dialog on user and system events.

Also, export all components in package `index.js` this should allow for easier imports in various projects.

```js
import { Button, ConfirmDialog, DataTable, useDataTable, ..etc } from "@reactioncommerce/catalyst"
```

## Testing
1. Test the ConfirmDialog examples