### PR TITLE
chore(deps): Bump node-fetch from 2.6.0 to 2.6.1

### DIFF
--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -7082,8 +7082,8 @@ node-fetch-npm@^2.0.2:
     safe-buffer "^5.1.1"
 
 node-fetch@^2.3.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
 
 node-forge@0.7.5:
   version "0.7.5"


### PR DESCRIPTION
Copy of https://github.com/reactioncommerce/catalyst/pull/175 with a new branch name. The docker-push is failing for the original PR and I think it's because of the branch name:

```
docker tag ****************/catalyst:0ebe03c1169c23e3ca0cfad20d0e6f7f269069af ****************/catalyst:dependabot/npm_and_yarn/package/node-fetch-2.6.1 
Error parsing reference: "****************/catalyst:dependabot/npm_and_yarn/package/node-fetch-2.6.1" is not a valid repository/tag: invalid reference format
```

---

Bumps [node-fetch](https://github.com/bitinn/node-fetch) from 2.6.0 to 2.6.1.
- [Release notes](https://github.com/bitinn/node-fetch/releases)
- [Changelog](https://github.com/node-fetch/node-fetch/blob/master/docs/CHANGELOG.md)
- [Commits](https://github.com/bitinn/node-fetch/compare/v2.6.0...v2.6.1)

Signed-off-by: dependabot[bot] <support@github.com>