### PR TITLE
chore: upgrade npm-user-validate

### DIFF
--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -7288,8 +7288,8 @@ npm-run-path@^2.0.0:
     path-key "^2.0.0"
 
 npm-user-validate@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.0.tgz#8ceca0f5cea04d4e93519ef72d0557a75122e951"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.1.tgz#31428fc5475fe8416023f178c0ab47935ad8c561"
 
 npm@^6.8.0:
   version "6.13.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8754,8 +8754,8 @@ npm-run-path@^2.0.0:
     path-key "^2.0.0"
 
 npm-user-validate@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.0.tgz#8ceca0f5cea04d4e93519ef72d0557a75122e951"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.1.tgz#31428fc5475fe8416023f178c0ab47935ad8c561"
 
 npm@^6.8.0:
   version "6.13.4"


### PR DESCRIPTION
https://github.com/reactioncommerce/catalyst/pull/180 and https://github.com/reactioncommerce/catalyst/pull/181 were failing in CircleCI at the docker tag step (I think it's because of the branch name). This PR contains these changes. 

Signed-off-by: Maria Paktiti <maria.paktiti@gmail.com>
